### PR TITLE
Proposed patches to add IA-16 far pointer support

### DIFF
--- a/gcc/c/c-decl.c
+++ b/gcc/c/c-decl.c
@@ -9524,6 +9524,9 @@ declspecs_add_addrspace (source_location location,
       specs->address_space = as;
       specs->locations[cdw_address_space] = location;
     }
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = true;
+#endif
   return specs;
 }
 
@@ -9540,6 +9543,9 @@ declspecs_add_qual (source_location loc,
   specs->declspecs_seen_p = true;
   gcc_assert (TREE_CODE (qual) == IDENTIFIER_NODE
 	      && C_IS_RESERVED_WORD (qual));
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = false;
+#endif
   i = C_RID_CODE (qual);
   switch (i)
     {
@@ -9583,6 +9589,9 @@ declspecs_add_type (location_t loc, struct c_declspecs *specs,
   specs->typespec_kind = spec.kind;
   if (TREE_DEPRECATED (type))
     specs->deprecated_p = true;
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = false;
+#endif
 
   /* Handle type specifier keywords.  */
   if (TREE_CODE (type) == IDENTIFIER_NODE
@@ -10332,6 +10341,9 @@ declspecs_add_scspec (source_location loc,
   specs->declspecs_seen_p = true;
   gcc_assert (TREE_CODE (scspec) == IDENTIFIER_NODE
 	      && C_IS_RESERVED_WORD (scspec));
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = false;
+#endif
   i = C_RID_CODE (scspec);
   if (specs->non_sc_seen_p)
     warning (OPT_Wold_style_declaration,
@@ -10443,6 +10455,9 @@ declspecs_add_scspec (source_location loc,
 struct c_declspecs *
 declspecs_add_attrs (source_location loc, struct c_declspecs *specs, tree attrs)
 {
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = false;
+#endif
   specs->attrs = chainon (attrs, specs->attrs);
   specs->locations[cdw_attributes] = loc;
   specs->declspecs_seen_p = true;
@@ -10457,6 +10472,9 @@ declspecs_add_alignas (source_location loc,
 		       struct c_declspecs *specs, tree align)
 {
   int align_log;
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  specs->address_space_is_last_p = false;
+#endif
   specs->alignas_p = true;
   specs->locations[cdw_alignas] = loc;
   if (align == error_mark_node)

--- a/gcc/c/c-tree.h
+++ b/gcc/c/c-tree.h
@@ -357,6 +357,11 @@ struct c_declspecs {
   /* Whether any alignment specifier (even with zero alignment) was
      specified.  */
   BOOL_BITFIELD alignas_p : 1;
+#ifdef TARGET_WARN_ADDR_SPACE_SYNTAX_P
+  /* Whether the address space specifier (below) comes last in the
+     declaration specifiers.  */
+  BOOL_BITFIELD address_space_is_last_p : 1;
+#endif
   /* The address space that the declaration belongs to.  */
   addr_space_t address_space;
 };

--- a/gcc/c/c-typeck.c
+++ b/gcc/c/c-typeck.c
@@ -13513,9 +13513,9 @@ c_build_qualified_type (tree type, int type_quals, tree orig_qual_type,
 	     element type.  This led to a compiler crash when trying to cast
 	     a far array to a far pointer.  -- tkchia  */
 	  TYPE_ADDR_SPACE (t) = TYPE_ADDR_SPACE (element_type);
-	  /* We should probably copy these too...  -- tkchia  */
-	  TYPE_READONLY (t) = TYPE_READONLY (element_type);
-	  TYPE_VOLATILE (t) = TYPE_VOLATILE (element_type);
+	  /* composite_type () does not allow any other qualifiers on array
+	     types, so do _not_ copy TYPE_READONLY (.), TYPE_VOLATILE (.),
+	     etc., over to the new type.  -- tkchia  */
 
           if (TYPE_STRUCTURAL_EQUALITY_P (element_type)
               || (domain && TYPE_STRUCTURAL_EQUALITY_P (domain)))

--- a/gcc/c/c-typeck.c
+++ b/gcc/c/c-typeck.c
@@ -13508,6 +13508,14 @@ c_build_qualified_type (tree type, int type_quals, tree orig_qual_type,
 
 	  t = build_variant_type_copy (type);
 	  TREE_TYPE (t) = element_type;
+	  /* Fix https://github.com/tkchia/gcc-ia16/issues/3 .  An array
+	     type was not marked as having the same address space as its
+	     element type.  This led to a compiler crash when trying to cast
+	     a far array to a far pointer.  -- tkchia  */
+	  TYPE_ADDR_SPACE (t) = TYPE_ADDR_SPACE (element_type);
+	  /* We should probably copy these too...  -- tkchia  */
+	  TYPE_READONLY (t) = TYPE_READONLY (element_type);
+	  TYPE_VOLATILE (t) = TYPE_VOLATILE (element_type);
 
           if (TYPE_STRUCTURAL_EQUALITY_P (element_type)
               || (domain && TYPE_STRUCTURAL_EQUALITY_P (domain)))

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -405,6 +405,8 @@ x86_64-*-*)
 	;;
 ia16-*-*)
 	cpu_type=ia16
+	c_target_objs="ia16-c.o"
+	cxx_target_objs="ia16-c.o"
 	target_has_targetm_common=no
 	;;
 ia64-*-*)

--- a/gcc/config/ia16/constraints.md
+++ b/gcc/config/ia16/constraints.md
@@ -73,7 +73,8 @@
 ; Special groups of registers.
 (define_register_constraint "A"	"DXAX_REGS"  "The @code{dx:ax} register pair.")
 (define_register_constraint "j"	"BXDX_REGS"  "The @code{bx:dx} register pair.")
-(define_register_constraint "Q" "SEGMENT_REGS"	"The @code{es} register.")
+(define_register_constraint "e" "SEGMENT_REGS"	"The @code{es} register.")
+(define_register_constraint "Q" "SEGMENT_REGS"	"A segment register.")
 (define_register_constraint "k"	"QISI_REGS"
 	"SImode registers with two 8-bit low parts.")
 

--- a/gcc/config/ia16/ia16-c.c
+++ b/gcc/config/ia16/ia16-c.c
@@ -1,6 +1,6 @@
 /* Subroutines used during code generation for Intel 16-bit x86.
    Copyright (C) 2011-2016 Free Software Foundation, Inc.
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/config/ia16/ia16-c.c
+++ b/gcc/config/ia16/ia16-c.c
@@ -1,0 +1,32 @@
+/* Subroutines used during code generation for Intel 16-bit x86.
+   Copyright (C) 2011-2016 Free Software Foundation, Inc.
+   Very preliminary far pointer support by TK Chia
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GCC is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "c-family/c-common.h"
+
+/* Implements REGISTER_TARGET_PRAGMAS.  */
+void
+ia16_register_pragmas (void)
+{
+  c_register_addr_space ("__far", ADDR_SPACE_FAR);
+}

--- a/gcc/config/ia16/ia16-peepholes.md
+++ b/gcc/config/ia16/ia16-peepholes.md
@@ -655,12 +655,13 @@
 ;	movw	mem,	%bx
 ; into
 ;	movw	mem,	%bx
-; This happens during reload, when far pointers are used in a loop.
+; This happens during reload, when far pointers are used in a loop.  Make
+; sure that %bx does not overlap with any registers used in mem.
 (define_peephole2
   [(set (match_operand:HI 0 "register_operand")
 	(match_operand:HI 1 "segment_register_operand"))
    (set (match_dup 0) (match_operand:HI 2 "memory_operand"))]
-  ""
+  "peep2_reg_dead_p (1, operands[0])"
   [(set (match_dup 0) (match_dup 2))]
   ""
 )

--- a/gcc/config/ia16/ia16-peepholes.md
+++ b/gcc/config/ia16/ia16-peepholes.md
@@ -651,6 +651,7 @@
 
 ; Try to rewrite
 ;	movw	%es,	%bx
+;   [	movw	%bx,	%es	]
 ;	movw	mem,	%bx
 ; into
 ;	movw	mem,	%bx

--- a/gcc/config/ia16/ia16-peepholes.md
+++ b/gcc/config/ia16/ia16-peepholes.md
@@ -642,7 +642,7 @@
 ; conversions.
 (define_peephole2
   [(set (match_operand:HI 0 "register_operand")
-	(match_operand:HI 1 "register_operand"))
+	(match_operand:HI 1 "segment_register_operand"))
    (set (match_dup 1) (match_dup 0))]
   ""
   [(set (match_dup 0) (match_dup 1))]
@@ -654,13 +654,11 @@
 ;	movw	mem,	%bx
 ; into
 ;	movw	mem,	%bx
-; This sequence (plus "movw %bx, %es" between the two instructions) is
-; generated during reload, when far pointers are used in a loop; this might
-; be due to address -> pointer and pointer -> address conversions.
+; This happens during reload, when far pointers are used in a loop.
 (define_peephole2
   [(set (match_operand:HI 0 "register_operand")
-	(match_operand:HI 1 "register_operand"))
-   (set (match_dup 0) (match_operand:HI 2 "general_operand"))]
+	(match_operand:HI 1 "segment_register_operand"))
+   (set (match_dup 0) (match_operand:HI 2 "memory_operand"))]
   ""
   [(set (match_dup 0) (match_dup 2))]
   ""

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -2,6 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
+   Very preliminary far pointer support by TK Chia
 
    This file is part of GCC.
 
@@ -51,3 +52,4 @@ extern bool	ia16_non_overlapping_mem_p (rtx m1, rtx m2);
 
 extern void	ia16_expand_prologue (void);
 extern void	ia16_expand_epilogue (bool sibcall);
+extern void	ia16_register_pragmas (void);

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -33,7 +33,7 @@ extern enum machine_mode
 
 #ifdef RTX_CODE
 extern void	ia16_initialize_trampoline (rtx addr, rtx fnaddr, rtx static_chain);
-extern bool	ia16_parse_address (rtx e, rtx *p_r1, rtx *p_r2, rtx *p_c);
+extern bool	ia16_parse_address (rtx e, rtx *p_r1, rtx *p_r2, rtx *p_c, rtx *p_r9);
 extern void	ia16_print_operand (FILE *file, rtx x, int code);
 extern void	ia16_print_operand_address (FILE *file, rtx x);
 #endif

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -2,7 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -31,9 +31,8 @@ extern HOST_WIDE_INT
 extern enum machine_mode
 		ia16_cc_modes_compatible (enum machine_mode mode1, enum machine_mode mode2);
 
-extern rtx	ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1,
-						     rtx target, machine_mode mode,
-						     unsigned modifier);
+extern rtx	ia16_expand_weird_pointer_plus_expr (rtx op0, rtx op1, rtx target,
+						     machine_mode mode);
 extern rtx	ia16_as_convert_weird_memory_address (machine_mode to_mode,
 						      rtx x, addr_space_t as,
 						      bool in_const, bool no_emit);

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -53,3 +53,6 @@ extern bool	ia16_non_overlapping_mem_p (rtx m1, rtx m2);
 extern void	ia16_expand_prologue (void);
 extern void	ia16_expand_epilogue (bool sibcall);
 extern void	ia16_register_pragmas (void);
+extern rtx	ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1,
+						     rtx target, machine_mode mode,
+						     unsigned modifier);

--- a/gcc/config/ia16/ia16-protos.h
+++ b/gcc/config/ia16/ia16-protos.h
@@ -31,6 +31,13 @@ extern HOST_WIDE_INT
 extern enum machine_mode
 		ia16_cc_modes_compatible (enum machine_mode mode1, enum machine_mode mode2);
 
+extern rtx	ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1,
+						     rtx target, machine_mode mode,
+						     unsigned modifier);
+extern rtx	ia16_as_convert_weird_memory_address (machine_mode to_mode,
+						      rtx x, addr_space_t as,
+						      bool in_const, bool no_emit);
+
 #ifdef RTX_CODE
 extern void	ia16_initialize_trampoline (rtx addr, rtx fnaddr, rtx static_chain);
 extern bool	ia16_parse_address (rtx e, rtx *p_r1, rtx *p_r2, rtx *p_c, rtx *p_r9);
@@ -53,6 +60,3 @@ extern bool	ia16_non_overlapping_mem_p (rtx m1, rtx m2);
 extern void	ia16_expand_prologue (void);
 extern void	ia16_expand_epilogue (bool sibcall);
 extern void	ia16_register_pragmas (void);
-extern rtx	ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1,
-						     rtx target, machine_mode mode,
-						     unsigned modifier);

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -577,17 +577,15 @@ ia16_as_convert_weird_memory_address (machine_mode to_mode, rtx x,
 }
 
 rtx
-ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1, rtx target,
-				     machine_mode mode, unsigned modifier)
+ia16_expand_weird_pointer_plus_expr (rtx op0, rtx op1, rtx target,
+				     machine_mode mode)
 {
-  enum expand_modifier mod = (enum expand_modifier) modifier;
-  rtx op0 = NULL_RTX, op1 = NULL_RTX, seg, op0_off, off, sum;
+  rtx seg, op0_off, off, sum;
 
   gcc_assert (mode == SImode || mode == VOIDmode);
-
-  expand_operands (treeop0, treeop1, NULL_RTX, &op0, &op1, mod);
   gcc_assert (GET_MODE (op0) == SImode || GET_MODE (op0) == VOIDmode);
   gcc_assert (GET_MODE (op1) == HImode || GET_MODE (op1) == VOIDmode);
+
   op0 = force_reg (SImode, op0);
 
   seg = gen_rtx_SUBREG (HImode, op0, 2);
@@ -595,7 +593,7 @@ ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1, rtx target,
 
   off = force_reg (HImode, gen_rtx_PLUS (HImode, op0_off, op1));
 
-  if (target && REG_P (target) && GET_MODE (target) == mode)
+  if (target && REG_P (target) && GET_MODE (target) == SImode)
     sum = target;
   else
     sum = gen_reg_rtx (SImode);

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -340,10 +340,10 @@ ia16_function_ok_for_sibcall (tree decl, tree exp ATTRIBUTE_UNUSED)
    0x0000:0xffff should give, say, 0x0000:0x0000.  */
 
 #undef  TARGET_ADDR_SPACE_ADDRESS_MODE
-#define TARGET_ADDR_SPACE_ADDRESS_MODE ia16_addr_space_address_mode
+#define TARGET_ADDR_SPACE_ADDRESS_MODE ia16_as_address_mode
 
 static enum machine_mode
-ia16_addr_space_address_mode (addr_space_t addrspace)
+ia16_as_address_mode (addr_space_t addrspace)
 {
   switch (addrspace)
     {
@@ -357,10 +357,10 @@ ia16_addr_space_address_mode (addr_space_t addrspace)
 }
 
 #undef  TARGET_ADDR_SPACE_POINTER_MODE
-#define TARGET_ADDR_SPACE_POINTER_MODE ia16_addr_space_pointer_mode
+#define TARGET_ADDR_SPACE_POINTER_MODE ia16_as_pointer_mode
 
 static machine_mode
-ia16_addr_space_pointer_mode (addr_space_t addrspace)
+ia16_as_pointer_mode (addr_space_t addrspace)
 {
   switch (addrspace)
     {
@@ -373,13 +373,21 @@ ia16_addr_space_pointer_mode (addr_space_t addrspace)
     }
 }
 
-#undef  TARGET_VALID_POINTER_MODE
-#define TARGET_VALID_POINTER_MODE ia16_valid_pointer_mode
+#undef  TARGET_ADDR_SPACE_VALID_POINTER_MODE
+#define TARGET_ADDR_SPACE_VALID_POINTER_MODE ia16_as_valid_pointer_mode
 
 static bool
-ia16_valid_pointer_mode (machine_mode m)
+ia16_as_valid_pointer_mode (machine_mode m, addr_space_t addrspace)
 {
-  return (m == HImode || m == SImode);
+  switch (addrspace)
+    {
+    case ADDR_SPACE_GENERIC:
+      return m == HImode;
+    case ADDR_SPACE_FAR:
+      return m == SImode;
+    default:
+      gcc_unreachable ();
+    }
 }
 
 static bool

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -583,9 +583,11 @@ ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1, rtx target,
   enum expand_modifier mod = (enum expand_modifier) modifier;
   rtx op0 = NULL_RTX, op1 = NULL_RTX, seg, op0_off, off, sum;
 
-  gcc_assert (mode == SImode);
+  gcc_assert (mode == SImode || mode == VOIDmode);
 
   expand_operands (treeop0, treeop1, NULL_RTX, &op0, &op1, mod);
+  gcc_assert (GET_MODE (op0) == SImode || GET_MODE (op0) == VOIDmode);
+  gcc_assert (GET_MODE (op1) == HImode || GET_MODE (op1) == VOIDmode);
   op0 = force_reg (SImode, op0);
 
   seg = gen_rtx_SUBREG (HImode, op0, 2);

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -530,14 +530,6 @@ ia16_as_convert_weird_memory_address (machine_mode to_mode, rtx x,
     if (no_emit)
       return NULL_RTX;
 
-    if (GET_MODE (x) == HImode)
-      {
-	/* This sometimes occurs due to GCC's internal probing.  */
-	r1 = force_reg (HImode, x);
-	r9 = force_reg (HImode, const0_rtx);
-      }
-    else
-
     gcc_assert (GET_MODE (x) == SImode || GET_MODE (x) == VOIDmode);
 
     x = force_reg (SImode, x);

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -651,9 +651,9 @@ ia16_split_seg_override_and_offset (rtx x, rtx *ovr, rtx *off)
       ia16_split_seg_override_and_offset (op0, &op0_ovr, &op0_off);
       *ovr = op0_ovr;
       if (! op0_off)
-	*off = op1;
+	*off = gen_rtx_NEG (m, op1);
       else
-	*off = gen_rtx_PLUS (m, op0_off, op1);
+	*off = gen_rtx_MINUS (m, op0_off, op1);
     }
 }
 

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -564,7 +564,7 @@ ia16_delegitimize_address (rtx x)
 
   x = gen_reg_rtx (SImode);
   emit_move_insn (gen_rtx_SUBREG (HImode, x, 0), off);
-  emit_move_insn (gen_rtx_SUBREG (HImode, x, 0), r9);
+  emit_move_insn (gen_rtx_SUBREG (HImode, x, 2), r9);
   return x;
 }
 

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -2,7 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -2,7 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
-   Very preliminary IA-16 far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support and other changes by TK Chia
 
    This file is part of GCC.
 
@@ -176,7 +176,8 @@ ia16_cannot_substitute_mem_equiv_p (rtx subst)
 int ia16_save_reg_p (unsigned int r)
 {
   if (r == BP_REG)
-    return get_frame_size() > 0 || crtl->args.info > 0 || cfun->calls_alloca;
+    return get_frame_size() > 0 || crtl->args.info > 0
+      || crtl->accesses_prior_frames || cfun->calls_alloca;
   if (!TEST_HARD_REG_BIT (reg_class_contents[QI_REGS], r))
     return (df_regs_ever_live_p (r) && !call_used_regs[r]);
   if (TEST_HARD_REG_BIT (reg_class_contents[UP_QI_REGS], r))

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -327,7 +327,7 @@ ia16_return_in_memory (const_tree type, const_tree fntype ATTRIBUTE_UNUSED)
 #undef  TARGET_FUNCTION_OK_FOR_SIBCALL
 #define TARGET_FUNCTION_OK_FOR_SIBCALL ia16_function_ok_for_sibcall
 static bool
-ia16_function_ok_for_sibcall (tree decl, tree exp)
+ia16_function_ok_for_sibcall (tree decl, tree exp ATTRIBUTE_UNUSED)
 {
   /* For now, only allow sibcalling known functions.
      TODO: Try relaxing this.  */
@@ -408,8 +408,8 @@ ia16_have_seg_override_p (rtx x)
 #define TARGET_ADDR_SPACE_LEGITIMATE_ADDRESS_P ia16_as_legitimate_address_p
 
 static bool
-ia16_as_legitimate_address_p (machine_mode mode, rtx x, bool strict,
-			      addr_space_t as)
+ia16_as_legitimate_address_p (machine_mode mode ATTRIBUTE_UNUSED, rtx x,
+			      bool strict, addr_space_t as)
 {
   rtx r1, r2, r9;
   if (as != ADDR_SPACE_GENERIC && !ia16_have_seg_override_p (x))
@@ -466,11 +466,29 @@ ia16_as_legitimate_address_p (machine_mode mode, rtx x, bool strict,
     && (REGNO_MODE_OK_FOR_REG_BASE_P (r1no, mode) || r1ok);
 }
 
+#undef  TARGET_ADDR_SPACE_ZERO_ADDRESS_VALID
+#define TARGET_ADDR_SPACE_ZERO_ADDRESS_VALID ia16_as_zero_address_valid
+
+static bool
+ia16_as_zero_address_valid (addr_space_t addrspace)
+{
+  switch (addrspace)
+    {
+    case ADDR_SPACE_GENERIC:
+      return false;
+    case ADDR_SPACE_FAR:
+      return true;
+    default:
+      gcc_unreachable ();
+    }
+}
+
 #undef  TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS
 #define TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS ia16_as_legitimize_address
 
 static rtx
-ia16_as_legitimize_address (rtx x, rtx oldx, machine_mode mode,
+ia16_as_legitimize_address (rtx x, rtx oldx ATTRIBUTE_UNUSED,
+			    machine_mode mode ATTRIBUTE_UNUSED,
 			    addr_space_t as)
 {
   rtx r1, r9;
@@ -1943,7 +1961,7 @@ ia16_parse_address_strict (rtx x, rtx *p_rb, rtx *p_ri, rtx *p_c, rtx *p_rs)
 {
 	rtx tmp;
 	rtx rb, ri, c, rs;
-	enum machine_mode mode;
+	enum machine_mode mode ATTRIBUTE_UNUSED;
 
 	if (!ia16_parse_address (x, &rb, &ri, &c, &rs))
 		return (0 == 1);

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -2159,13 +2159,11 @@ ia16_parse_address_internal (rtx e, rtx *p_r1, rtx *p_r2, rtx *p_c, rtx *p_r9)
 bool
 ia16_parse_address (rtx e, rtx *p_r1, rtx *p_r2, rtx *p_c, rtx *p_r9)
 {
-  rtx r1, r2, c;
-  if (ia16_parse_address_internal (e, &r1, &r2, &c, p_r9))
+  rtx r1, c;
+  if (ia16_parse_address_internal (e, &r1, p_r2, &c, p_r9))
     {
       if (p_r1)
 	*p_r1 = r1;
-      if (p_r2)
-	*p_r2 = r2;
       if (p_c)
 	{
 	  if (c || r1)

--- a/gcc/config/ia16/ia16.c
+++ b/gcc/config/ia16/ia16.c
@@ -2619,7 +2619,7 @@ ia16_expand_weird_pointer_plus_expr (tree treeop0, tree treeop1, rtx target,
 
   gcc_assert (mode == SImode);
 
-  op0 = expand_expr (treeop0, NULL_RTX, SImode, mod);
+  op0 = force_reg (SImode, expand_expr (treeop0, NULL_RTX, SImode, mod));
   op1 = expand_expr (treeop1, NULL_RTX, HImode, mod);
 
   seg = gen_rtx_SUBREG (HImode, op0, 2);

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -584,6 +584,10 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
 #define FUNCTION_MODE			QImode
 
 #define ADDR_SPACE_FAR			1
+/* We hack gcc/tree-ssa-loop-ivopts.c to recognize a new macro
+   TARGET_ADDR_SPACE_WEIRD_P (as), which should return true if the given
+   address space breaks certain assumptions made by optimization passes.  */
+#define TARGET_ADDR_SPACE_WEIRD_P(as)	((as) == ADDR_SPACE_FAR)
 
 /* Which processor to tune code generation for.  These must be in sync
    with processor_target_table in ia16.c.  */

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -239,6 +239,17 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
 #define MODE_BASE_REG_REG_CLASS(mode)	INDEX_REGS
 #define INDEX_REG_CLASS			BASE_W_INDEX_REGS
 
+/* We hack gcc/lra-constraints.c to recognize and use a new macro
+ * MODE_SEGMENT_REG_CLASS(mode, unspec_op), which should be a set of
+ * registers to use for an RTL expression <expr> occurring in a SEGMENT term,
+ *	(unspec:<mode> [<expr> ...] <unspec_op>)
+ * if this SEGMENT term is part of an address.  For IA-16, the form is
+ *	(unspec:HI [<expr>] UNSPEC_SEG_OVERRIDE)
+ * and we want to get <expr> loaded into a segment register (well, %es).
+ */
+#define MODE_SEGMENT_REG_CLASS(mode, unspec_op) \
+	((unspec_op) == UNSPEC_SEG_OVERRIDE ? SEGMENT_REGS : NO_REGS)
+
 /* FIXME: Documentation:
  * It is unclear if these definitions should be guarded by REG_OK_STRICT or not.  */
 #define REGNO_MODE_OK_FOR_BASE_P(num, mode)	((num) < FIRST_PSEUDO_REGISTER && \

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -2,7 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -2,7 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
-   Very preliminary IA-16 far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support and other changes by TK Chia
 
    This file is part of GCC.
 
@@ -313,10 +313,15 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
    return address and the frame pointer, we can't find the return address for
    count > 0.
    TODO: Make this work by pushing the frame pointer before the saved regs
-   when not using ENTER.  */
+   when not using ENTER.
+
+   For count == 0, set a flag so that ia16_save_reg_p (.) will ultimately
+   arrange to allocate a frame pointer, even if the function does not
+   otherwise need one.  */
 #define RETURN_ADDR_RTX(COUNT, FRAME)				       	      \
 	((COUNT) == 0							      \
-	 ? gen_rtx_MEM (Pmode, arg_pointer_rtx)				      \
+	 ? crtl->accesses_prior_frames = true,				      \
+	   gen_rtx_MEM (Pmode, arg_pointer_rtx)				      \
 	 : NULL_RTX)
 
 /* Exception Handling Support */

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -33,7 +33,10 @@
 
 /* Run-time Target Specification */
 #define TARGET_CPU_CPP_BUILTINS()	\
-	do { builtin_define_std ("ia16"); } while (0)
+	do {				\
+	  builtin_define_std ("ia16");	\
+	  builtin_define ("__FAR");	\
+	} while (0)
 
 /* Storage Layout
  *

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -240,14 +240,15 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
 #define INDEX_REG_CLASS			BASE_W_INDEX_REGS
 
 /* We hack gcc/lra-constraints.c to recognize and use a new macro
- * MODE_SEGMENT_REG_CLASS(mode, unspec_op), which should be a set of
- * registers to use for an RTL expression <expr> occurring in a SEGMENT term,
+ * MODE_SEGMENT_REG_CLASS (outer_mode, inner_mode, unspec_op), which should
+ * be a set of registers to use for an RTL expression <expr> occurring in a
+ * SEGMENT term,
  *	(unspec:<mode> [<expr> ...] <unspec_op>)
  * if this SEGMENT term is part of an address.  For IA-16, the form is
  *	(unspec:HI [<expr>] UNSPEC_SEG_OVERRIDE)
  * and we want to get <expr> loaded into a segment register (well, %es).
  */
-#define MODE_SEGMENT_REG_CLASS(mode, unspec_op) \
+#define MODE_SEGMENT_REG_CLASS(outer_mode, inner_mode, unspec_op) \
 	((unspec_op) == UNSPEC_SEG_OVERRIDE ? SEGMENT_REGS : NO_REGS)
 
 /* FIXME: Documentation:

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -2,6 +2,7 @@
    Copyright (C) 2005-2017 Free Software Foundation, Inc.
    Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
    Changes by Andrew Jenner <andrew@codesourcery.com>
+   Very preliminary far pointer support by TK Chia
 
    This file is part of GCC.
 
@@ -532,6 +533,8 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
 /* Macros for SDB and DWARF Output  */
 #undef DWARF2_DEBUGGING_INFO
 
+#define REGISTER_TARGET_PRAGMAS() ia16_register_pragmas ()
+
 /* Cross Compilation and Floating Point
  * Skipped for now.
 
@@ -563,6 +566,7 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
 #define Pmode				HImode
 #define FUNCTION_MODE			QImode
 
+#define ADDR_SPACE_FAR			1
 
 /* Which processor to tune code generation for.  These must be in sync
    with processor_target_table in ia16.c.  */

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -591,6 +591,12 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
    TARGET_ADDR_SPACE_WEIRD_P (as), which should return true if the given
    address space breaks certain assumptions made by optimization passes.  */
 #define TARGET_ADDR_SPACE_WEIRD_P(as)	((as) == ADDR_SPACE_FAR)
+/* We also hack gcc/expr.c to recognize TARGET_ADDR_SPACE_WEIRD_P (as) ---
+   as well as another macro TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (treeop0,
+   treeop1, target, mode, modifier).  The latter macro should say how to
+   convert a POINTER_PLUS_EXPR node into RTL, when the pointer operand
+   (treeop0) belongs to a "weird" address space.  */
+#define TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR ia16_expand_weird_pointer_plus_expr
 
 /* Which processor to tune code generation for.  These must be in sync
    with processor_target_table in ia16.c.  */

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -597,6 +597,11 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
    convert a POINTER_PLUS_EXPR node into RTL, when the pointer operand
    (treeop0) belongs to a "weird" address space.  */
 #define TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR ia16_expand_weird_pointer_plus_expr
+/* And, we hack gcc/explow.c to recognize a new macro to actually do address
+   RTX -> pointer RTX and pointer RTX -> address RTX conversions for operands
+   pointing into "weird" address spaces.  */
+#define TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS \
+	ia16_as_convert_weird_memory_address
 
 /* Which processor to tune code generation for.  These must be in sync
    with processor_target_table in ia16.c.  */

--- a/gcc/config/ia16/ia16.h
+++ b/gcc/config/ia16/ia16.h
@@ -591,6 +591,11 @@ enum reg_class {	/*	 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0 */
    TARGET_ADDR_SPACE_WEIRD_P (as), which should return true if the given
    address space breaks certain assumptions made by optimization passes.  */
 #define TARGET_ADDR_SPACE_WEIRD_P(as)	((as) == ADDR_SPACE_FAR)
+/* We hack gcc/c/c-parser.c to recognize TARGET_WARN_ADDR_SPACE_SYNTAX_P
+   (as), which should return true if an address space name is traditionally
+   considered as part of a `declarator' rather than `declaration-specifiers'
+   grammar-wise.  */
+#define TARGET_WARN_ADDR_SPACE_SYNTAX_P(as) ((as) == ADDR_SPACE_FAR)
 /* We also hack gcc/expr.c to recognize TARGET_ADDR_SPACE_WEIRD_P (as) ---
    as well as another macro TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (treeop0,
    treeop1, target, mode, modifier).  The latter macro should say how to

--- a/gcc/config/ia16/ia16.md
+++ b/gcc/config/ia16/ia16.md
@@ -2,7 +2,7 @@
 ;  Copyright (C) 2005-2017 Free Software Foundation, Inc.
 ;  Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
 ;  Changes by Andrew Jenner <andrew@codesourcery.com>
-;  Very preliminary far pointer support by TK Chia
+;  Very preliminary IA-16 far pointer support by TK Chia
 ;
 ;  This file is part of GCC.
 ;

--- a/gcc/config/ia16/ia16.md
+++ b/gcc/config/ia16/ia16.md
@@ -37,6 +37,8 @@
 
 	 (UNSPEC_NOT_CARRY	0)
 	 (UNSPEC_SEG_OVERRIDE	1)
+	 (UNSPEC_SEG_SS_VAL	2)
+	 (UNSPEC_SEG_CS_VAL	3)
 	])
 
 ; Mode Iterators
@@ -2599,3 +2601,15 @@
   [(unspec:HI [(match_operand:HI 0 "" "")] UNSPEC_SEG_OVERRIDE)]
   ""
   "")
+
+(define_insn "movhi_ss"
+  [(set (match_operand:HI 0 "nonimmediate_operand" "=rm")
+	(unspec:HI [(const_int 0)] UNSPEC_SEG_SS_VAL))]
+  ""
+  "movw\t%%ss,\t%0")
+
+(define_insn "movhi_cs"
+  [(set (match_operand:HI 0 "nonimmediate_operand" "=rm")
+	(unspec:HI [(const_int 0)] UNSPEC_SEG_CS_VAL))]
+  ""
+  "movw\t%%cs,\t%0")

--- a/gcc/config/ia16/ia16.md
+++ b/gcc/config/ia16/ia16.md
@@ -2,6 +2,7 @@
 ;  Copyright (C) 2005-2017 Free Software Foundation, Inc.
 ;  Contributed by Rask Ingemann Lambertsen <rask@sygehus.dk>
 ;  Changes by Andrew Jenner <andrew@codesourcery.com>
+;  Very preliminary far pointer support by TK Chia
 ;
 ;  This file is part of GCC.
 ;
@@ -35,6 +36,7 @@
 	 (ARGP_REG	14)
 
 	 (UNSPEC_NOT_CARRY	0)
+	 (UNSPEC_SEG_OVERRIDE	1)
 	])
 
 ; Mode Iterators
@@ -2592,3 +2594,8 @@
 	""
 	"lock\;xchg<s>\t%0,\t%1"
 )
+
+(define_expand "seg_override"
+  [(unspec:HI [(match_operand:HI 0 "" "")] UNSPEC_SEG_OVERRIDE)]
+  ""
+  "")

--- a/gcc/config/ia16/t-ia16
+++ b/gcc/config/ia16/t-ia16
@@ -1,5 +1,8 @@
 # 16.1 Target Makefile Fragments
 
+ia16-c.o: $(srcdir)/config/ia16/ia16-c.c $(RTL_H) $(TREE_H) $(CONFIG_H) $(TM_H)
+	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) $<
+
 MULTILIB_OPTIONS=march=any_186/Os/fno-omit-frame-pointer/fno-split-wide-types
 MULTILIB_DIRNAMES=any_186 size frame-pointer wide-types
 MULTILIB_MATCHES=march?any_186=march?i80186 march?any_186=march?i80188 \

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1461,9 +1461,9 @@ resulting pointer is undefined.  This may change in the future.
 
 @item
 Many kinds of useful operations involving far addresses are not yet
-supported.  These include casting from a generic 16-bit pointer to a far
-pointer, and placing a static storage @emph{variable} in the @code{__far}
-space.
+supported.  These include placing a static storage @emph{variable} in the
+@code{__far} space, and creating a far function pointer (e.g., @code{size_t
+(__far *pf) (int);}).
 
 @end itemize
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1495,32 +1495,15 @@ compilers such as Open Watcom C/C++ and Borland's Turbo C.  The code
 char __far *p, *q;
 @end smallexample
 
-declares both @code{p} and @code{q} as far pointers under GCC, but under
-Open Watcom it declares only @code{p} as a far pointer, and @code{q} as a
-generic pointer.  Moreover, GCC does @emph{not} support the Watcom-style
-syntax
+declares @code{p} and @code{q} as far pointers under GCC, but under Open
+Watcom it declares only @code{p} as a far pointer, and @code{q} as a generic
+pointer.
 
-@smallexample
-char __far *p, __far *q;
-@end smallexample
-
-and conversely Open Watcom does not allow placing the word @samp{__far}
-before @samp{char}, which GCC allows:
-
-@smallexample
-__far char *p, *q;
-@end smallexample
-@c
-@c Bart Oldeman suggested (https://github.com/tkchia/gcc-ia16/issues/11
-@c #issuecomment-344935397) that it would be good for GCC to issue compiler
-@c warnings for cases like
-@c	char __far *p, *q;
-@c
-@c I quite agree, but the C parser code (gcc/c/c-parser.c) looks quite hairy
-@c at the moment, plus named address spaces are also used for other
-@c platforms.  So I am not sure I want to touch the code before really
-@c thinking things through.  Perhaps someone who is not me can step up to the
-@c task. :-)  -- tkchia
+@opindex Waddress
+@opindex Wall
+If @option{-Waddress} (or @option{-Wall}) is enabled, GCC will warn about
+cases like the above, where a declaration can be interpreted differently
+under GCC's grammar and Watcom-style grammar.
 
 @end itemize
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1452,11 +1452,6 @@ unsigned long irq0_clock_ticks (void)
 @itemize
 
 @item
-Presently, far pointers must point to @code{volatile} items---writing
-@code{void __far *} rather than @code{volatile void __far *} may crash the
-compiler.  This is a bug which needs fixing.
-
-@item
 If a pointer arithmetic operation causes the pointer's offset portion to
 wrap around---from @code{0xFFFF} to @code{0x0000}, or vice versa---the
 resulting pointer is undefined.  This may change in the future.

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1268,7 +1268,7 @@ As an extension, GNU C supports named address spaces as
 defined in the N1275 draft of ISO/IEC DTR 18037.  Support for named
 address spaces in GCC will evolve as the draft technical report
 changes.  Calling conventions for any target might also change.  At
-present, only the AVR, SPU, M32C, RL78, and x86 targets support
+present, only the AVR, SPU, M32C, RL78, IA-16, and x86 targets support
 address spaces other than the generic address space.
 
 Address space identifiers may be used exactly like any other C type
@@ -1471,8 +1471,56 @@ resulting pointer is undefined.  This may change in the future.
 @item
 Many kinds of useful operations involving far addresses are not yet
 supported.  These include placing a static storage @emph{variable} in the
-@code{__far} space, and creating a far function pointer (e.g., @code{size_t
-(__far *pf) (int);}).
+@code{__far} space, and invoking a far @emph{function}.
+@c
+@c The N1275 draft does not actually support the notion of functions in
+@c separate address spaces: (5.1.2) "Note that, since a function is not an
+@c object, address-space type qualifiers cannot be used with functions."
+@c
+@c However, GCC _does_ seem to allow declarations of far function pointers
+@c (perhaps unintentionally).  One needs to say e.g.
+@c	typedef int fn_t (char);
+@c	typedef __far fn_t *p_far_fn_t;
+@c Trying to call a function via such a pointer will currently crash GCC.
+@c
+@c The classical `int (__far *) (char);' declaration syntax does not work
+@c (see below).  -- tkchia
+
+@item
+For far pointer declarations, the GCC named address space syntax---which
+follows N1275---differs somewhat from the syntax used in classical DOS
+compilers such as Open Watcom C/C++ and Borland's Turbo C.  The code
+
+@smallexample
+char __far *p, *q;
+@end smallexample
+
+declares both @code{p} and @code{q} as far pointers under GCC, but under
+Open Watcom it declares only @code{p} as a far pointer, and @code{q} as a
+generic pointer.  Moreover, GCC does @emph{not} support the Watcom-style
+syntax
+
+@smallexample
+char __far *p, __far *q;
+@end smallexample
+
+and conversely Open Watcom does not allow placing the word @samp{__far}
+before @samp{char}, which GCC allows:
+
+@smallexample
+__far char *p, *q;
+@end smallexample
+@c
+@c Bart Oldeman suggested (https://github.com/tkchia/gcc-ia16/issues/11
+@c #issuecomment-344935397) that it would be good for GCC to issue compiler
+@c warnings for cases like
+@c	char __far *p, *q;
+@c
+@c I quite agree, but the C parser code (gcc/c/c-parser.c) looks quite hairy
+@c at the moment, plus named address spaces are also used for other
+@c platforms.  So I am not sure I want to touch the code before really
+@c thinking things through.  Perhaps someone who is not me can step up to the
+@c task. :-)  -- tkchia
 
 @end itemize
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1458,9 +1458,16 @@ supported.
 If a pointer arithmetic operation causes the pointer's offset portion to
 wrap around---from @code{0xFFFF} to @code{0x0000}, or vice versa---the
 resulting pointer is undefined.  This may change in the future.
-@c Currently far pointers are treated as plain old 32-bit integers (except
-@c when dereferenced), so 0x1234:0xFFFF wraps around to 0x1235:0x0000, but
-@c this is silly and does not really make sense.
+@c
+@c (Nov 2017) I have modified gcc-ia16 so that it does far pointer
+@c arithmetic in the same fashion as in classical DOS compilers, i.e. only
+@c the low 16-bit offset is frobbed.  However, it is still not as efficient
+@c as it should be (`movw %es, %dx; movw %dx, %es; ...'), and it probably
+@c needs to be more rigorously tested.
+@c
+@c Before the hack, gcc-ia16 treated far pointers as plain old 32-bit
+@c integers, so that 0x1234:0xFFFF wrapped around to 0x1235:0x0000, which
+@c made no sense.  -- tkchia
 
 @item
 Many kinds of useful operations involving far addresses are not yet

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1452,6 +1452,11 @@ unsigned long irq0_clock_ticks (void)
 @itemize
 
 @item
+Presently, far pointers must point to @code{volatile} items---writing
+@code{void __far *} rather than @code{volatile void __far *} may crash the
+compiler.  This is a bug which needs fixing.
+
+@item
 If a pointer arithmetic operation causes the pointer's offset portion to
 wrap around---from @code{0xFFFF} to @code{0x0000}, or vice versa---the
 resulting pointer is undefined.  This may change in the future.
@@ -1460,9 +1465,10 @@ resulting pointer is undefined.  This may change in the future.
 @c this is silly and does not really make sense.
 
 @item
-Many kinds of useful operations involving far addresses---such as casting
-from a generic 16-bit pointer to a far pointer, and placing a static storage
-@emph{variable} in the @code{__far} space---are not yet supported.
+Many kinds of useful operations involving far addresses are not yet
+supported.  These include casting from a generic 16-bit pointer to a far
+pointer, and placing a static storage @emph{variable} in the @code{__far}
+space.
 
 @end itemize
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1461,9 +1461,8 @@ resulting pointer is undefined.  This may change in the future.
 @c
 @c (Nov 2017) I have modified gcc-ia16 so that it does far pointer
 @c arithmetic in the same fashion as in classical DOS compilers, i.e. only
-@c the low 16-bit offset is frobbed.  However, it is still not as efficient
-@c as it should be (`movw %es, %dx; movw %dx, %es; ...'), and it probably
-@c needs to be more rigorously tested.
+@c the low 16-bit offset is frobbed.  However, it probably needs to be more
+@c rigorously tested.
 @c
 @c Before the hack, gcc-ia16 treated far pointers as plain old 32-bit
 @c integers, so that 0x1234:0xFFFF wrapped around to 0x1235:0x0000, which

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1446,6 +1446,9 @@ unsigned long irq0_clock_ticks (void)
 @}
 @end smallexample
 
+The preprocessor symbol @code{__FAR} is defined when far pointers are
+supported.
+
 @noindent
 @b{Limitations and caveats}
 

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -1424,6 +1424,48 @@ Such code requires at least binutils 2.23, see
 
 @end itemize
 
+@subsection IA-16 Named Address Spaces
+@cindex @code{__far} IA-16 Named Address Spaces
+
+On the IA-16 target, a pointer qualified with the word @code{__far} is a
+32-bit ``far pointer'' which can be used to access memory outside of the
+64@tie{}KiB generic address space.
+
+One way to create a far pointer value is to cast a 32-bit integer value to a
+far pointer type.  The value's upper 16 bits will be the segment, and the
+lower 16 bits the offset.
+
+@smallexample
+unsigned long irq0_clock_ticks (void)
+@{
+    /* Read the 32-bit BIOS variable at segment:offset ==
+       0x0040:0x006C.  */
+    volatile unsigned long __far *p =
+        (volatile unsigned long __far *) 0x0040006C;
+    return *p;
+@}
+@end smallexample
+
+@noindent
+@b{Limitations and caveats}
+
+@itemize
+
+@item
+If a pointer arithmetic operation causes the pointer's offset portion to
+wrap around---from @code{0xFFFF} to @code{0x0000}, or vice versa---the
+resulting pointer is undefined.  This may change in the future.
+@c Currently far pointers are treated as plain old 32-bit integers (except
+@c when dereferenced), so 0x1234:0xFFFF wraps around to 0x1235:0x0000, but
+@c this is silly and does not really make sense.
+
+@item
+Many kinds of useful operations involving far addresses---such as casting
+from a generic 16-bit pointer to a far pointer, and placing a static storage
+@emph{variable} in the @code{__far} space---are not yet supported.
+
+@end itemize
+
 @subsection M32C Named Address Spaces
 @cindex @code{__far} M32C Named Address Spaces
 

--- a/gcc/doc/md.texi
+++ b/gcc/doc/md.texi
@@ -2438,8 +2438,13 @@ The @code{bx} and @code{bp} registers.
 @item B
 The @code{bx}, @code{si}, @code{di} and @code{bp} registers.
 
+@item e
+The @code{es} register.
+
 @item Q
-Any segment register.
+Any segment register.  (This is currently the same as @code{e},
+but might include @code{ds} in the future if it becomes
+available for allocation.)
 
 @item Z
 The constant 0.

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -10437,6 +10437,20 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
+@defmac TARGET_WARN_ADDR_SPACE_SYNTAX_P (@var{as})
+This macro is not needed for most targets.  For the IA-16 target, it is used
+to issue a warning for declarations such as
+
+@smallexample
+char __far *p, *q;
+@end smallexample
+
+which might be parsed differently under GCC (@code{*q} is in @code{__far}
+space) and under older IA-16 compilers (@code{*q} is in generic space).  If
+defined, the macro should return true if such a warning might apply to
+declarations involving address space @var{as}.
+@end defmac
+
 @defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{op0}, @var{op1}, @var{target}, @var{mode})
 This macro is not needed for most targets.  If defined, it says how to do
 pointer arithmetic over ``weird'' address spaces.

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -2426,6 +2426,25 @@ address where its value is either multiplied by a scale factor or
 added to another register (as well as added to a displacement).
 @end defmac
 
+@defmac MODE_SEGMENT_REG_CLASS (@var{outer_mode}, @var{inner_mode}, @var{index})
+A macro which, if defined, should return a register class to control the
+loading of addresses' ``segment'' components into registers.
+
+This macro is not needed for targets with only flat address spaces---that is
+to say, most targets.  It is used in the IA-16 backend to implement
+@code{__far} pointers.
+
+With this macro, if a memory address contains a segment component in the
+form of an RTL expression
+@smallexample
+(unspec:@var{outer_mode} [@var{expr} @dots{}] @var{index})
+@end smallexample
+then GCC will consult this macro to decide which register class to load the
+inner expression @var{expr} into.  @var{inner_mode} is the mode of this
+inner expression, while @var{outer_mode} and @var{index} are the mode and
+the operation code for the @samp{(unspec @dots{})} as a whole.
+@end defmac
+
 @defmac REGNO_OK_FOR_BASE_P (@var{num})
 A C expression which is nonzero if register number @var{num} is
 suitable for use as a base register in operand addresses.

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -10455,6 +10455,17 @@ This macro is defined in the IA-16 backend to implement @code{__far} pointer
 arithmetic in a proper way.
 @end defmac
 
+@defmac TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS (@var{to_mode}, @var{x}, @var{as}, @var{in_const}, @var{no_emit})
+This macro is not needed for most targets.  If defined, @emph{and} if
+@code{POINTERS_EXTEND_UNSIGNED} is undefined, this macro says how to convert
+from addresses to pointers, or from pointers to addresses, for ``weird''
+address spaces.  The arguments have the same meanings as in
+@samp{convert_memory_address_addr_space_1 ()}.
+
+This macro is defined in the IA-16 backend to implement conversions between
+@code{__far} pointers and @code{__far} addresses.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -10437,18 +10437,18 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
-@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{tree_op0}, @var{tree_op1}, @var{target}, @var{mode}, @var{modifier})
+@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{op0}, @var{op1}, @var{target}, @var{mode})
 This macro is not needed for most targets.  If defined, it says how to do
 pointer arithmetic over ``weird'' address spaces.
 
-More precisely, GCC invokes this macro on the operands of a
+More precisely, GCC invokes this macro on the processed operands of a
 @code{POINTER_PLUS_EXPR} tree, if the pointer/reference operand points into
 an address space for which @code{TARGET_ADDR_SPACE_WEIRD_P} is true.
 
-@var{tree_op0} will be the first operand in the @code{POINTER_PLUS_EXPR}
-expression (i.e., the pointer/reference), and @var{tree_op1} the second
-operand (i.e., the unsigned displacement).  The arguments @var{target},
-@var{mode}, and @var{modifier} have the same meanings as in
+@var{op0} will be an RTX expanded from the first operand in the
+@code{POINTER_PLUS_EXPR} expression (i.e., the pointer/reference), and
+@var{op1} an RTX for the second operand (i.e., the unsigned displacement).
+The arguments @var{target} and @var{mode} have the same meanings as in
 @samp{expand_expr ()} and @samp{expand_expr_real ()}.
 
 This macro is defined in the IA-16 backend to implement @code{__far} pointer

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -10437,6 +10437,24 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
+@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{tree_op0}, @var{tree_op1}, @var{target}, @var{mode}, @var{modifier})
+This macro is not needed for most targets.  If defined, it says how to do
+pointer arithmetic over ``weird'' address spaces.
+
+More precisely, GCC invokes this macro on the operands of a
+@code{POINTER_PLUS_EXPR} tree, if the pointer/reference operand points into
+an address space for which @code{TARGET_ADDR_SPACE_WEIRD_P} is true.
+
+@var{tree_op0} will be the first operand in the @code{POINTER_PLUS_EXPR}
+expression (i.e., the pointer/reference), and @var{tree_op1} the second
+operand (i.e., the unsigned displacement).  The arguments @var{target},
+@var{mode}, and @var{modifier} have the same meanings as in
+@samp{expand_expr ()} and @samp{expand_expr_real ()}.
+
+This macro is defined in the IA-16 backend to implement @code{__far} pointer
+arithmetic in a proper way.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi
+++ b/gcc/doc/tm.texi
@@ -10417,6 +10417,26 @@ Define this to define how the address space is encoded in dwarf.
 The result is the value to be used with @code{DW_AT_address_class}.
 @end deftypefn
 
+@defmac TARGET_ADDR_SPACE_WEIRD_P (@var{as})
+This macro is not needed for most targets.  If defined, it should return
+true if pointers and addresses in the address space @var{as} may break
+certain assumptions.  In particular, it should return true if
+
+@enumerate
+@item
+pointer or address arithmetic does not work in the same way as integer
+arithmetic of the same modes, or if
+
+@item
+the difference between two pointers or addresses might not fit into a
+@code{sizetype}.
+
+@end enumerate
+
+This macro is defined in the IA-16 backend to suppress certain optimizations
+over @code{__far} pointers.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -7523,6 +7523,17 @@ This macro is defined in the IA-16 backend to implement @code{__far} pointer
 arithmetic in a proper way.
 @end defmac
 
+@defmac TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS (@var{to_mode}, @var{x}, @var{as}, @var{in_const}, @var{no_emit})
+This macro is not needed for most targets.  If defined, @emph{and} if
+@code{POINTERS_EXTEND_UNSIGNED} is undefined, this macro says how to convert
+from addresses to pointers, or from pointers to addresses, for ``weird''
+address spaces.  The arguments have the same meanings as in
+@samp{convert_memory_address_addr_space_1 ()}.
+
+This macro is defined in the IA-16 backend to implement conversions between
+@code{__far} pointers and @code{__far} addresses.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -2220,6 +2220,25 @@ address where its value is either multiplied by a scale factor or
 added to another register (as well as added to a displacement).
 @end defmac
 
+@defmac MODE_SEGMENT_REG_CLASS (@var{outer_mode}, @var{inner_mode}, @var{index})
+A macro which, if defined, should return a register class to control the
+loading of addresses' ``segment'' components into registers.
+
+This macro is not needed for targets with only flat address spaces---that is
+to say, most targets.  It is used in the IA-16 backend to implement
+@code{__far} pointers.
+
+With this macro, if a memory address contains a segment component in the
+form of an RTL expression
+@smallexample
+(unspec:@var{outer_mode} [@var{expr} @dots{}] @var{index})
+@end smallexample
+then GCC will consult this macro to decide which register class to load the
+inner expression @var{expr} into.  @var{inner_mode} is the mode of this
+inner expression, while @var{outer_mode} and @var{index} are the mode and
+the operation code for the @samp{(unspec @dots{})} as a whole.
+@end defmac
+
 @defmac REGNO_OK_FOR_BASE_P (@var{num})
 A C expression which is nonzero if register number @var{num} is
 suitable for use as a base register in operand addresses.

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -7505,18 +7505,18 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
-@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{tree_op0}, @var{tree_op1}, @var{target}, @var{mode}, @var{modifier})
+@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{op0}, @var{op1}, @var{target}, @var{mode})
 This macro is not needed for most targets.  If defined, it says how to do
 pointer arithmetic over ``weird'' address spaces.
 
-More precisely, GCC invokes this macro on the operands of a
+More precisely, GCC invokes this macro on the processed operands of a
 @code{POINTER_PLUS_EXPR} tree, if the pointer/reference operand points into
 an address space for which @code{TARGET_ADDR_SPACE_WEIRD_P} is true.
 
-@var{tree_op0} will be the first operand in the @code{POINTER_PLUS_EXPR}
-expression (i.e., the pointer/reference), and @var{tree_op1} the second
-operand (i.e., the unsigned displacement).  The arguments @var{target},
-@var{mode}, and @var{modifier} have the same meanings as in
+@var{op0} will be an RTX expanded from the first operand in the
+@code{POINTER_PLUS_EXPR} expression (i.e., the pointer/reference), and
+@var{op1} an RTX for the second operand (i.e., the unsigned displacement).
+The arguments @var{target} and @var{mode} have the same meanings as in
 @samp{expand_expr ()} and @samp{expand_expr_real ()}.
 
 This macro is defined in the IA-16 backend to implement @code{__far} pointer

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -7485,6 +7485,26 @@ c_register_addr_space ("__ea", ADDR_SPACE_EA);
 
 @hook TARGET_ADDR_SPACE_DEBUG
 
+@defmac TARGET_ADDR_SPACE_WEIRD_P (@var{as})
+This macro is not needed for most targets.  If defined, it should return
+true if pointers and addresses in the address space @var{as} may break
+certain assumptions.  In particular, it should return true if
+
+@enumerate
+@item
+pointer or address arithmetic does not work in the same way as integer
+arithmetic of the same modes, or if
+
+@item
+the difference between two pointers or addresses might not fit into a
+@code{sizetype}.
+
+@end enumerate
+
+This macro is defined in the IA-16 backend to suppress certain optimizations
+over @code{__far} pointers.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -7505,6 +7505,24 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
+@defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{tree_op0}, @var{tree_op1}, @var{target}, @var{mode}, @var{modifier})
+This macro is not needed for most targets.  If defined, it says how to do
+pointer arithmetic over ``weird'' address spaces.
+
+More precisely, GCC invokes this macro on the operands of a
+@code{POINTER_PLUS_EXPR} tree, if the pointer/reference operand points into
+an address space for which @code{TARGET_ADDR_SPACE_WEIRD_P} is true.
+
+@var{tree_op0} will be the first operand in the @code{POINTER_PLUS_EXPR}
+expression (i.e., the pointer/reference), and @var{tree_op1} the second
+operand (i.e., the unsigned displacement).  The arguments @var{target},
+@var{mode}, and @var{modifier} have the same meanings as in
+@samp{expand_expr ()} and @samp{expand_expr_real ()}.
+
+This macro is defined in the IA-16 backend to implement @code{__far} pointer
+arithmetic in a proper way.
+@end defmac
+
 @node Misc
 @section Miscellaneous Parameters
 @cindex parameters, miscellaneous

--- a/gcc/doc/tm.texi.in
+++ b/gcc/doc/tm.texi.in
@@ -7505,6 +7505,20 @@ This macro is defined in the IA-16 backend to suppress certain optimizations
 over @code{__far} pointers.
 @end defmac
 
+@defmac TARGET_WARN_ADDR_SPACE_SYNTAX_P (@var{as})
+This macro is not needed for most targets.  For the IA-16 target, it is used
+to issue a warning for declarations such as
+
+@smallexample
+char __far *p, *q;
+@end smallexample
+
+which might be parsed differently under GCC (@code{*q} is in @code{__far}
+space) and under older IA-16 compilers (@code{*q} is in generic space).  If
+defined, the macro should return true if such a warning might apply to
+declarations involving address space @var{as}.
+@end defmac
+
 @defmac TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (@var{op0}, @var{op1}, @var{target}, @var{mode})
 This macro is not needed for most targets.  If defined, it says how to do
 pointer arithmetic over ``weird'' address spaces.

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -1,5 +1,6 @@
 /* Subroutines for manipulating rtx's in semantically interesting ways.
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
+   Very preliminary far pointer support by TK Chia
 
 This file is part of GCC.
 
@@ -397,7 +398,13 @@ memory_address_addr_space (machine_mode mode, rtx x, addr_space_t as)
   /* By passing constant addresses through registers
      we get a chance to cse them.  */
   if (! cse_not_expected && CONSTANT_P (x) && CONSTANT_ADDRESS_P (x))
-    x = force_reg (address_mode, x);
+    {
+      x = force_reg (address_mode, x);
+
+      /* TODO: Remove need for this ia16-elf far pointer hack.  */
+      if (! memory_address_addr_space_p (mode, x, as))
+	x = targetm.addr_space.legitimize_address (x, oldx, mode, as);
+    }
 
   /* We get better cse by rejecting indirect addressing at this stage.
      Let the combiner create indirect addresses where appropriate.

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -191,14 +191,15 @@ plus_constant (machine_mode mode, rtx x, HOST_WIDE_INT c,
 
 rtx
 pointer_plus_constant (machine_mode mode, rtx x, HOST_WIDE_INT c,
-		       addr_space_t as, unsigned modifier, bool inplace)
+		       addr_space_t as, bool inplace)
 {
 #ifdef TARGET_ADDR_SPACE_WEIRD_P
 # ifdef TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR
+  machine_mode size_mode = TYPE_MODE (sizetype);
   if (TARGET_ADDR_SPACE_WEIRD_P (as))
-    return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (x, gen_int_mode (c, mode),
-						  inplace ? x : NULL_RTX,
-						  mode);
+    return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (x,
+						  gen_int_mode (c, size_mode),
+						  NULL_RTX, mode);
 # endif
 #endif
   return plus_constant (mode, x, c, inplace);

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -1,6 +1,6 @@
 /* Subroutines for manipulating rtx's in semantically interesting ways.
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
 This file is part of GCC.
 

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -277,14 +277,17 @@ convert_memory_address_addr_space_1 (machine_mode to_mode ATTRIBUTE_UNUSED,
 				     bool no_emit ATTRIBUTE_UNUSED)
 {
 #ifndef POINTERS_EXTEND_UNSIGNED
-# ifdef MODE_SEGMENT_REG_CLASS
+# ifdef TARGET_ADDR_SPACE_WEIRD_P
+#  ifdef TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS
   /* Special case for ia16-elf pointer -> address and address -> pointer
      conversions.  Is there a better way?  */
-  if (GET_MODE (x) != to_mode)
-    x = targetm.addr_space.legitimize_address (x, x, to_mode, as);
+  if (GET_MODE (x) != to_mode && TARGET_ADDR_SPACE_WEIRD_P (as))
+    x = TARGET_ADDR_SPACE_CONVERT_WEIRD_MEMORY_ADDRESS (to_mode, x, as,
+							in_const, no_emit);
+#  endif
 # endif
 
-  if (GET_MODE (x) != to_mode && GET_MODE (x) != VOIDmode)
+  if (! x || (GET_MODE (x) != to_mode && GET_MODE (x) != VOIDmode))
     {
       fprintf (stderr,
 	       "trying to convert pointer or address in address space %d\n"

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -277,6 +277,18 @@ convert_memory_address_addr_space_1 (machine_mode to_mode ATTRIBUTE_UNUSED,
 				     bool no_emit ATTRIBUTE_UNUSED)
 {
 #ifndef POINTERS_EXTEND_UNSIGNED
+# ifdef MODE_SEGMENT_REG_CLASS
+  /* Special case for ia16-elf pointer -> address and address -> pointer
+     conversions.  Is there a better way?  */
+  if (GET_MODE (x) != to_mode)
+    {
+      if (to_mode == targetm.addr_space.pointer_mode (as))
+	x = targetm.delegitimize_address (x);
+      else
+	x = targetm.addr_space.legitimize_address (x, x, to_mode, as);
+    }
+# endif
+
   if (GET_MODE (x) != to_mode && GET_MODE (x) != VOIDmode)
     {
       fprintf (stderr,
@@ -385,14 +397,7 @@ convert_memory_address_addr_space_1 (machine_mode to_mode ATTRIBUTE_UNUSED,
 rtx
 convert_memory_address_addr_space (machine_mode to_mode, rtx x, addr_space_t as)
 {
-  x = convert_memory_address_addr_space_1 (to_mode, x, as, false, false);
-
-  /* Special hack for ia16-elf pointer-to-address conversions.  */
-  if (as != ADDR_SPACE_GENERIC
-      && ! memory_address_addr_space_p (to_mode, x, as))
-    x = targetm.addr_space.legitimize_address (x, x, to_mode, as);
-
-  return x;
+  return convert_memory_address_addr_space_1 (to_mode, x, as, false, false);
 }
 
 

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -1,6 +1,5 @@
 /* Subroutines for manipulating rtx's in semantically interesting ways.
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
-   Very preliminary IA-16 far pointer support by TK Chia
 
 This file is part of GCC.
 

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -281,12 +281,7 @@ convert_memory_address_addr_space_1 (machine_mode to_mode ATTRIBUTE_UNUSED,
   /* Special case for ia16-elf pointer -> address and address -> pointer
      conversions.  Is there a better way?  */
   if (GET_MODE (x) != to_mode)
-    {
-      if (to_mode == targetm.addr_space.pointer_mode (as))
-	x = targetm.delegitimize_address (x);
-      else
-	x = targetm.addr_space.legitimize_address (x, x, to_mode, as);
-    }
+    x = targetm.addr_space.legitimize_address (x, x, to_mode, as);
 # endif
 
   if (GET_MODE (x) != to_mode && GET_MODE (x) != VOIDmode)

--- a/gcc/explow.c
+++ b/gcc/explow.c
@@ -186,6 +186,24 @@ plus_constant (machine_mode mode, rtx x, HOST_WIDE_INT c,
     return x;
 }
 
+/* Like plus_constant, but X is assumed to be a pointer somewhere into an
+   address space AS, and AS may be "weird" (TARGET_ADDR_SPACE_WEIRD_P).  */
+
+rtx
+pointer_plus_constant (machine_mode mode, rtx x, HOST_WIDE_INT c,
+		       addr_space_t as, unsigned modifier, bool inplace)
+{
+#ifdef TARGET_ADDR_SPACE_WEIRD_P
+# ifdef TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR
+  if (TARGET_ADDR_SPACE_WEIRD_P (as))
+    return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (x, gen_int_mode (c, mode),
+						  inplace ? x : NULL_RTX,
+						  mode);
+# endif
+#endif
+  return plus_constant (mode, x, c, inplace);
+}
+
 /* If X is a sum, return a new sum like X but lacking any constant terms.
    Add all the removed constant terms into *CONSTPTR.
    X itself is not altered.  The result != X if and only if

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -8274,6 +8274,15 @@ expand_expr_real_2 (sepops ops, rtx target, machine_mode tmode,
       }
 
     case POINTER_PLUS_EXPR:
+#ifdef TARGET_ADDR_SPACE_WEIRD_P
+# ifdef TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR
+      /* Special case for ia16-elf.  */
+      if (TARGET_ADDR_SPACE_WEIRD_P (TYPE_ADDR_SPACE
+	  (TREE_TYPE (TREE_TYPE (treeop0)))))
+	return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (treeop0, treeop1,
+						      target, tmode, modifier);
+# endif
+#endif
       /* Even though the sizetype mode and the pointer's mode can be different
          expand is able to handle this correctly and get the correct result out
          of the PLUS_EXPR code.  */

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -7759,7 +7759,8 @@ expand_expr_addr_expr_1 (tree exp, rtx target, machine_mode tmode,
       gcc_assert ((bitpos % BITS_PER_UNIT) == 0);
 
       result = convert_memory_address_addr_space (tmode, result, as);
-      result = plus_constant (tmode, result, bitpos / BITS_PER_UNIT);
+      result = pointer_plus_constant (tmode, result, bitpos / BITS_PER_UNIT,
+				      as, modifier);
       if (modifier < EXPAND_SUM)
 	result = force_operand (result, target);
     }
@@ -8279,8 +8280,13 @@ expand_expr_real_2 (sepops ops, rtx target, machine_mode tmode,
       /* Special case for ia16-elf.  */
       if (TARGET_ADDR_SPACE_WEIRD_P (TYPE_ADDR_SPACE
 	  (TREE_TYPE (TREE_TYPE (treeop0)))))
-	return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (treeop0, treeop1,
-						      target, tmode, modifier);
+	{
+	  rtx op0 = NULL_RTX, op1 = NULL_RTX;
+
+	  expand_operands (treeop0, treeop1, NULL_RTX, &op0, &op1, modifier);
+	  return TARGET_EXPAND_WEIRD_POINTER_PLUS_EXPR (op0, op1, target,
+							tmode);
+	}
 # endif
 #endif
       /* Even though the sizetype mode and the pointer's mode can be different

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -7760,7 +7760,7 @@ expand_expr_addr_expr_1 (tree exp, rtx target, machine_mode tmode,
 
       result = convert_memory_address_addr_space (tmode, result, as);
       result = pointer_plus_constant (tmode, result, bitpos / BITS_PER_UNIT,
-				      as, modifier);
+				      as);
       if (modifier < EXPAND_SUM)
 	result = force_operand (result, target);
     }

--- a/gcc/lra-constraints.c
+++ b/gcc/lra-constraints.c
@@ -1,7 +1,6 @@
 /* Code for RTL transformations to satisfy insn constraints.
    Copyright (C) 2010-2016 Free Software Foundation, Inc.
    Contributed by Vladimir Makarov <vmakarov@redhat.com>.
-   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/lra-constraints.c
+++ b/gcc/lra-constraints.c
@@ -1,7 +1,7 @@
 /* Code for RTL transformations to satisfy insn constraints.
    Copyright (C) 2010-2016 Free Software Foundation, Inc.
    Contributed by Vladimir Makarov <vmakarov@redhat.com>.
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/lra-constraints.c
+++ b/gcc/lra-constraints.c
@@ -376,8 +376,6 @@ segment_subterm (rtx *segment_term)
   if (MODE_SEGMENT_REG_CLASS (GET_MODE (e), GET_MODE (XVECEXP (e, 0, 0)),
 			      XINT (e, 1)) == NO_REGS)
     return NULL;
-  if (XVECLEN (e, 0) == 0)
-    return NULL;
   return &XVECEXP (e, 0, 0);
 }
 #endif
@@ -3001,35 +2999,6 @@ process_address_1 (int nop, bool check_only_p,
   else
     return false;
 
-#ifdef MODE_SEGMENT_REG_CLASS
-  if (ad.segment != NULL)
-    {
-      rtx *term = ad.segment_term;
-# if 0
-      fprintf (stderr, "ad.segment: 1\n");
-      debug_rtx (*term);
-# endif
-      rtx *subterm = segment_subterm (term);
-      if (subterm)
-	{
-# if 0
-	  fprintf (stderr, "ad.segment: 2\n");
-	  debug_rtx (*subterm);
-# endif
-	  enum reg_class cl = MODE_SEGMENT_REG_CLASS (GET_MODE (*term),
-				GET_MODE (*subterm), XINT (*term, 1));
-	  if (cl != NO_REGS)
-	    {
-	      if (process_addr_reg (subterm, check_only_p, before, NULL, cl))
-		change_p = true;
-	    }
-# if 0
-	  fprintf (stderr, "ad.segment: 3\n");
-	  debug_rtx (*subterm);
-# endif
-	}
-    }
-#endif
 
   /* If INDEX_REG_CLASS is assigned to base_term already and isn't to
      index_term, swap them so to avoid assigning INDEX_REG_CLASS to both
@@ -3047,6 +3016,23 @@ process_address_1 (int nop, bool check_only_p,
     }
   if (! check_only_p)
     change_p = equiv_address_substitution (&ad);
+#ifdef MODE_SEGMENT_REG_CLASS
+  if (ad.segment_term != NULL)
+    {
+      rtx *term = ad.segment_term;
+      rtx *subterm = segment_subterm (term);
+      if (subterm)
+	{
+	  enum reg_class cl = MODE_SEGMENT_REG_CLASS (GET_MODE (*term),
+				GET_MODE (*subterm), XINT (*term, 1));
+	  if (cl != NO_REGS)
+	    {
+	      if (process_addr_reg (subterm, check_only_p, before, NULL, cl))
+		change_p = true;
+	    }
+	}
+    }
+#endif
   if (ad.base_term != NULL
       && (process_addr_reg
 	  (ad.base_term, check_only_p, before,

--- a/gcc/lra-constraints.c
+++ b/gcc/lra-constraints.c
@@ -371,7 +371,10 @@ segment_subterm (rtx *segment_term)
     return NULL;
   e = *segment_term;
   gcc_assert (GET_CODE (e) == UNSPEC);
-  if (MODE_SEGMENT_REG_CLASS (GET_MODE (e), XINT (e, 1)) == NO_REGS)
+  if (XVECLEN (e, 0) < 1)
+    return NULL;
+  if (MODE_SEGMENT_REG_CLASS (GET_MODE (e), GET_MODE (XVECEXP (e, 0, 0)),
+			      XINT (e, 1)) == NO_REGS)
     return NULL;
   if (XVECLEN (e, 0) == 0)
     return NULL;
@@ -3015,7 +3018,7 @@ process_address_1 (int nop, bool check_only_p,
 # endif
 	  rtx_insn *last;
 	  enum reg_class cl = MODE_SEGMENT_REG_CLASS (GET_MODE (*term),
-						      XINT (*term, 1));
+				GET_MODE (*subterm), XINT (*term, 1));
 	  push_to_sequence (*before);
 	  last = get_last_insn ();
 	  if (cl != NO_REGS)

--- a/gcc/lra-constraints.c
+++ b/gcc/lra-constraints.c
@@ -3016,27 +3016,17 @@ process_address_1 (int nop, bool check_only_p,
 	  fprintf (stderr, "ad.segment: 2\n");
 	  debug_rtx (*subterm);
 # endif
-	  rtx_insn *last;
 	  enum reg_class cl = MODE_SEGMENT_REG_CLASS (GET_MODE (*term),
 				GET_MODE (*subterm), XINT (*term, 1));
-	  push_to_sequence (*before);
-	  last = get_last_insn ();
 	  if (cl != NO_REGS)
 	    {
-	      rtx new_seg_reg = lra_create_new_reg (GET_MODE (*subterm),
-						    NULL_RTX, cl, "seg");
-	      rtx_insn *insn = emit_insn (gen_rtx_SET (new_seg_reg, *subterm));
-	      if (recog_memoized (insn) >= 0)
-		*subterm = new_seg_reg;
-	      else
-		delete_insns_since (last);
-# if 0
-	      fprintf (stderr, "ad.segment: 3\n");
-	      debug_rtx (*subterm);
-# endif
-	      *before = get_insns ();
+	      if (process_addr_reg (subterm, check_only_p, before, NULL, cl))
+		change_p = true;
 	    }
-	  end_sequence ();
+# if 0
+	  fprintf (stderr, "ad.segment: 3\n");
+	  debug_rtx (*subterm);
+# endif
 	}
     }
 #endif

--- a/gcc/regcprop.c
+++ b/gcc/regcprop.c
@@ -1,6 +1,5 @@
 /* Copy propagation on hard registers for the GNU compiler.
    Copyright (C) 2000-2016 Free Software Foundation, Inc.
-   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 

--- a/gcc/regcprop.c
+++ b/gcc/regcprop.c
@@ -636,6 +636,13 @@ replace_oldest_value_addr (rtx *loc, enum reg_class cl,
     case REG:
       return replace_oldest_value_reg (loc, cl, insn, vd);
 
+#ifdef MODE_SEGMENT_REG_CLASS
+    case UNSPEC:
+      if (MODE_SEGMENT_REG_CLASS (GET_MODE (x), XINT (x, 1)) != NO_REGS)
+	return false;
+      break;
+#endif
+
     default:
       break;
     }

--- a/gcc/regcprop.c
+++ b/gcc/regcprop.c
@@ -1,5 +1,6 @@
 /* Copy propagation on hard registers for the GNU compiler.
    Copyright (C) 2000-2016 Free Software Foundation, Inc.
+   Very preliminary IA-16 far pointer support by TK Chia
 
    This file is part of GCC.
 
@@ -95,7 +96,8 @@ static bool replace_oldest_value_reg (rtx *, enum reg_class, rtx_insn *,
 				      struct value_data *);
 static bool replace_oldest_value_addr (rtx *, enum reg_class,
 				       machine_mode, addr_space_t,
-				       rtx_insn *, struct value_data *);
+				       rtx_insn *, struct value_data *,
+				       enum rtx_code);
 static bool replace_oldest_value_mem (rtx, rtx_insn *, struct value_data *);
 static bool copyprop_hardreg_forward_1 (basic_block, struct value_data *);
 extern void debug_value_data (struct value_data *);
@@ -507,7 +509,8 @@ replace_oldest_value_reg (rtx *loc, enum reg_class cl, rtx_insn *insn,
 static bool
 replace_oldest_value_addr (rtx *loc, enum reg_class cl,
 			   machine_mode mode, addr_space_t as,
-			   rtx_insn *insn, struct value_data *vd)
+			   rtx_insn *insn, struct value_data *vd,
+			   enum rtx_code on_high_index_code)
 {
   rtx x = *loc;
   RTX_CODE code = GET_CODE (x);
@@ -606,14 +609,16 @@ replace_oldest_value_addr (rtx *loc, enum reg_class cl,
 	    index_code = GET_CODE (*locI);
 	  }
 
+	if (on_high_index_code == REG)
+	  index_code = REG;
 	if (locI)
 	  changed |= replace_oldest_value_addr (locI, INDEX_REG_CLASS,
-						mode, as, insn, vd);
+						mode, as, insn, vd, index_code);
 	if (locB)
 	  changed |= replace_oldest_value_addr (locB,
 						base_reg_class (mode, as, PLUS,
 								index_code),
-						mode, as, insn, vd);
+						mode, as, insn, vd, index_code);
 	return changed;
       }
 
@@ -640,11 +645,12 @@ replace_oldest_value_addr (rtx *loc, enum reg_class cl,
     {
       if (fmt[i] == 'e')
 	changed |= replace_oldest_value_addr (&XEXP (x, i), cl, mode, as,
-					      insn, vd);
+					      insn, vd, on_high_index_code);
       else if (fmt[i] == 'E')
 	for (j = XVECLEN (x, i) - 1; j >= 0; j--)
 	  changed |= replace_oldest_value_addr (&XVECEXP (x, i, j), cl,
-						mode, as, insn, vd);
+						mode, as, insn, vd,
+						on_high_index_code);
     }
 
   return changed;
@@ -664,7 +670,7 @@ replace_oldest_value_mem (rtx x, rtx_insn *insn, struct value_data *vd)
 
   return replace_oldest_value_addr (&XEXP (x, 0), cl,
 				    GET_MODE (x), MEM_ADDR_SPACE (x),
-				    insn, vd);
+				    insn, vd, SCRATCH);
 }
 
 /* Apply all queued updates for DEBUG_INSNs that change some reg to
@@ -761,7 +767,8 @@ copyprop_hardreg_forward_1 (basic_block bb, struct value_data *vd)
 	      if (!VAR_LOC_UNKNOWN_P (loc))
 		replace_oldest_value_addr (&INSN_VAR_LOCATION_LOC (insn),
 					   ALL_REGS, GET_MODE (loc),
-					   ADDR_SPACE_GENERIC, insn, vd);
+					   ADDR_SPACE_GENERIC, insn, vd,
+					   SCRATCH);
 	    }
 
 	  if (insn == BB_END (bb))
@@ -932,7 +939,7 @@ copyprop_hardreg_forward_1 (basic_block bb, struct value_data *vd)
 		  = replace_oldest_value_addr (recog_data.operand_loc[i],
 					       alternative_class (op_alt, i),
 					       VOIDmode, ADDR_SPACE_GENERIC,
-					       insn, vd);
+					       insn, vd, SCRATCH);
 	      else if (REG_P (recog_data.operand[i]))
 		replaced[i]
 		  = replace_oldest_value_reg (recog_data.operand_loc[i],

--- a/gcc/regcprop.c
+++ b/gcc/regcprop.c
@@ -633,7 +633,10 @@ replace_oldest_value_addr (rtx *loc, enum reg_class cl,
 
 #ifdef MODE_SEGMENT_REG_CLASS
     case UNSPEC:
-      if (MODE_SEGMENT_REG_CLASS (GET_MODE (x), XINT (x, 1)) != NO_REGS)
+      if (XVECLEN (x, 0) < 1)
+	break;
+      if (MODE_SEGMENT_REG_CLASS (GET_MODE (x), GET_MODE (XVECEXP (x, 0, 0)),
+				  XINT (x, 1)) != NO_REGS)
 	return false;
       break;
 #endif

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -2658,6 +2658,8 @@ get_full_set_src_cost (rtx x, machine_mode mode, struct full_rtx_costs *c)
 /* In explow.c */
 extern HOST_WIDE_INT trunc_int_for_mode	(HOST_WIDE_INT, machine_mode);
 extern rtx plus_constant (machine_mode, rtx, HOST_WIDE_INT, bool = false);
+extern rtx pointer_plus_constant (machine_mode, rtx, HOST_WIDE_INT,
+				  addr_space_t, unsigned, bool = false);
 
 /* In rtl.c */
 extern rtx rtx_alloc_stat (RTX_CODE MEM_STAT_DECL);

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -2027,8 +2027,8 @@ struct address_info {
        because that's its most typical use.  It contains exactly one UNSPEC,
        pointed to by SEGMENT_TERM.  The contents of *SEGMENT do not need
        reloading (unless the back-end machine description defines the macro
-       MODE_SEGMENT_REG_CLASS(mode, unspec_op), which will control the
-       reloading).
+       MODE_SEGMENT_REG_CLASS (outer_mode, inner_mode, unspec_op), which will
+       control the reloading).
 
      - *BASE is a variable expression representing a base address.
        It contains exactly one REG, SUBREG or MEM, pointed to by BASE_TERM.

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -2659,7 +2659,7 @@ get_full_set_src_cost (rtx x, machine_mode mode, struct full_rtx_costs *c)
 extern HOST_WIDE_INT trunc_int_for_mode	(HOST_WIDE_INT, machine_mode);
 extern rtx plus_constant (machine_mode, rtx, HOST_WIDE_INT, bool = false);
 extern rtx pointer_plus_constant (machine_mode, rtx, HOST_WIDE_INT,
-				  addr_space_t, unsigned, bool = false);
+				  addr_space_t, bool = false);
 
 /* In rtl.c */
 extern rtx rtx_alloc_stat (RTX_CODE MEM_STAT_DECL);

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -1,5 +1,6 @@
 /* Register Transfer Language (RTL) definitions for GCC
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
+   Very preliminary far pointer support by TK Chia
 
 This file is part of GCC.
 
@@ -2026,7 +2027,9 @@ struct address_info {
        This value is entirely target-specific and is only called a "segment"
        because that's its most typical use.  It contains exactly one UNSPEC,
        pointed to by SEGMENT_TERM.  The contents of *SEGMENT do not need
-       reloading.
+       reloading (unless the back-end machine description defines the macro
+       MODE_SEGMENT_REG_CLASS(mode, unspec_op), which will control the
+       reloading).
 
      - *BASE is a variable expression representing a base address.
        It contains exactly one REG, SUBREG or MEM, pointed to by BASE_TERM.

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -1,6 +1,6 @@
 /* Register Transfer Language (RTL) definitions for GCC
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
-   Very preliminary far pointer support by TK Chia
+   Very preliminary IA-16 far pointer support by TK Chia
 
 This file is part of GCC.
 

--- a/gcc/rtl.h
+++ b/gcc/rtl.h
@@ -1,6 +1,5 @@
 /* Register Transfer Language (RTL) definitions for GCC
    Copyright (C) 1987-2016 Free Software Foundation, Inc.
-   Very preliminary IA-16 far pointer support by TK Chia
 
 This file is part of GCC.
 

--- a/gcc/testsuite/gcc.target/ia16/far-addr-1.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-1.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
 /* Test for basic far pointer functionality.  Also test that the preprocessor

--- a/gcc/testsuite/gcc.target/ia16/far-addr-1.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-1.c
@@ -1,13 +1,18 @@
 /* { dg-do compile } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* Test for basic far pointer functionality. */
+/* Test for basic far pointer functionality.  Also test that the preprocessor
+   macro __FAR is defined.  */
 
 unsigned long
 irq0_clock_ticks (void)
 {
+#ifdef __FAR
   volatile unsigned long __far *p =
     (volatile unsigned long __far *) 0x0040006C;
   return *p;
+#else
+# error
+#endif
 }
 /* { dg-final { scan-assembler "movw\[ \\t\]%\[de\]s:" } } */

--- a/gcc/testsuite/gcc.target/ia16/far-addr-1.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-1.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* Test for basic far pointer functionality. */
+
+unsigned long
+irq0_clock_ticks (void)
+{
+  volatile unsigned long __far *p =
+    (volatile unsigned long __far *) 0x0040006C;
+  return *p;
+}
+/* { dg-final { scan-assembler "movw\[ \\t\]%\[de\]s:" } } */

--- a/gcc/testsuite/gcc.target/ia16/far-addr-10.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-10.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-options "-O1 --save-temps" } */
+
+/* Test for a far pointer processing bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/2 .  */
+
+struct string_int {
+  char str[1];
+  int number;
+};
+
+int p_number_not_zero(struct string_int __far *p)
+{
+  return p->number != 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-10.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-10.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O1 --save-temps" } */
 
 /* Test for a far pointer processing bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/far-addr-11.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-11.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-O1 --save-temps" } */
+
+/* Test for a pointer processing bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/5 .  */
+
+void scan(int __far *p)
+{
+  for(; *p; p++);
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-11.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-11.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O1 --save-temps" } */
 
 /* Test for a pointer processing bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/far-addr-12.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-12.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O1 --save-temps" } */
 
 /* Test for a pointer processing bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/far-addr-12.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-12.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-O1 --save-temps" } */
+
+/* Test for a pointer processing bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/6 .  */
+
+struct x2 {
+  char x[2];
+} psp;
+
+int get_p_x_i(struct x2 __far *p, int i)
+{
+  return p->x[i];
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-13.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-13.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-options "-Os --save-temps" } */
+
+/* First test case for a pointer processing bug reported by Bart Oldeman ---
+   see https://github.com/tkchia/gcc-ia16/issues/7 .  */
+
+struct x2 {
+  char x[2];
+} psp;
+
+extern void foo(char __far *p);
+
+void foo_p_x_i(struct x2 __far *p, int i)
+{
+  foo(&p->x[i]);
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-13.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-13.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-Os --save-temps" } */
 
 /* First test case for a pointer processing bug reported by Bart Oldeman ---

--- a/gcc/testsuite/gcc.target/ia16/far-addr-14.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-14.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-Og --save-temps" } */
+
+/* Second test case for a pointer processing bug reported by Bart Oldeman
+   --- see https://github.com/tkchia/gcc-ia16/issues/7 .  */
+
+char p_i(char __far *p, int i)
+{
+  return p[i];
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-14.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-14.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-Og --save-temps" } */
 
 /* Second test case for a pointer processing bug reported by Bart Oldeman

--- a/gcc/testsuite/gcc.target/ia16/far-addr-15.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-15.c
@@ -1,0 +1,30 @@
+/* { dg-do compile } */
+/* { dg-xfail-if "" *-*-* } */
+/* { dg-excess-errors "" } */
+/* { dg-options "-O0 --save-temps" } */
+
+/* FAIL: Casting an array within a far structure to a pointer.  Bug was
+   reported by Bart Oldeman --- https://github.com/tkchia/gcc-ia16/issues/3 .
+
+   A workaround for now is to write the function call as something like
+   `farstr(&p->str[0]);' .
+
+   About the bug: apparently somehow, at some point in the compilation, the
+   fact that the array `p->str' is in the far address space gets lost.  GCC
+   thus thinks that the array -> pointer conversion also needs to cast a
+   generic (near) pointer to a far pointer, leading to weirdness.
+
+   This seems to be a bug in the type logic of GCC's machine-independent
+   GENERIC tree code.  If so, it may well apply to other GCC ports that
+   support named address spaces.  */
+
+struct string1 {
+  char str[1];
+};
+
+void farstr(char __far *);
+
+void call_farstr(struct string1 __far *p)
+{
+  farstr(p->str);
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-15.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-15.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O0 --save-temps" } */
 
 /* Casting an array within a far structure to a pointer.  Bug was reported

--- a/gcc/testsuite/gcc.target/ia16/far-addr-15.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-15.c
@@ -1,22 +1,16 @@
 /* { dg-do compile } */
-/* { dg-xfail-if "" *-*-* } */
-/* { dg-excess-errors "" } */
 /* { dg-options "-O0 --save-temps" } */
 
-/* FAIL: Casting an array within a far structure to a pointer.  Bug was
-   reported by Bart Oldeman --- https://github.com/tkchia/gcc-ia16/issues/3 .
+/* Casting an array within a far structure to a pointer.  Bug was reported
+   by Bart Oldeman --- https://github.com/tkchia/gcc-ia16/issues/3 .
 
-   A workaround for now is to write the function call as something like
-   `farstr(&p->str[0]);' .
+   The bug was caused by c_build_qualified_type (...) (in gcc/c/c-typeck.c)
+   failing to propagate the address space information of an array's element
+   type to the array type itself.
 
-   About the bug: apparently somehow, at some point in the compilation, the
-   fact that the array `p->str' is in the far address space gets lost.  GCC
-   thus thinks that the array -> pointer conversion also needs to cast a
-   generic (near) pointer to a far pointer, leading to weirdness.
-
-   This seems to be a bug in the type logic of GCC's machine-independent
-   GENERIC tree code.  If so, it may well apply to other GCC ports that
-   support named address spaces.  */
+   A similar routine exists on the C++ side, but (as of Nov 2017) the GNU
+   C++ compiler does not yet support named address spaces, so will not
+   currently trigger this bug.  */
 
 struct string1 {
   char str[1];

--- a/gcc/testsuite/gcc.target/ia16/far-addr-16.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-16.c
@@ -1,0 +1,121 @@
+/* { dg-do run } */
+/* { dg-options "-mcmodel=tiny -O3 -fno-inline --save-temps" } */
+
+/* Check if far pointers wrap around right (i.e. only the offsets wrap) when
+   we use pointer arithmetic to access fields in far structures.  */
+
+#define MK_FP(seg, off) \
+	((void __far *) ((unsigned long) (unsigned) (seg) << 16 | \
+					 (unsigned) (off)))
+#define FLUFF_AMOUNT	0x0badu
+
+int printf (const char *, ...);
+void abort (void);
+
+struct s1
+{
+  unsigned p, q, r, s;
+};
+
+struct s2
+{
+  unsigned fluff[FLUFF_AMOUNT], p, q, r, s;
+};
+
+static unsigned
+ss (void)
+{
+  unsigned x;
+  __asm ("movw %%ss, %0" : "=r" (x));
+  return x;
+}
+
+void __far *
+addr_1 (void)
+{
+  return MK_FP (0xf000, 0xff00);
+}
+
+void __far *
+addr_2 (void)
+{
+  return MK_FP (0xfff0, -FLUFF_AMOUNT * sizeof (unsigned));
+}
+
+void __far *
+addr_3 (void)
+{
+  return MK_FP (ss (), 0x100);
+}
+
+void __far *
+addr_4 (void)
+{
+  return MK_FP (ss (), 0x100 - FLUFF_AMOUNT * sizeof (unsigned));
+}
+
+int
+main (void)
+{
+  struct s1 __far *as1 = addr_1 ();
+  struct s2 __far *as2 = addr_2 ();
+  struct s1 __far *as3 = addr_3 ();
+  struct s2 __far *as4 = addr_4 ();
+  unsigned p1, q1, r1, s1, p2, q2, r2, s2, p3, q3, r3, s3, p4, q4, r4, s4;
+
+  printf ("as1 = %#lx, as2 = %#lx\n",
+	  (unsigned long) as1, (unsigned long) as2);
+
+  p1 = as1->p;
+  p2 = as2->p;
+  printf ("p1 = %#x, p2 = %#x\n", p1, p2);
+  if (p1 != p2)
+    abort ();
+
+  q1 = as1->q;
+  q2 = as2->q;
+  printf ("q1 = %#x, q2 = %#x\n", q1, q2);
+  if (q1 != q2)
+    abort ();
+
+  r1 = as1->r;
+  r2 = as2->r;
+  printf ("r1 = %#x, r2 = %#x\n", r1, r2);
+  if (r1 != r2)
+    abort ();
+
+  s1 = as1->s;
+  s2 = as2->s;
+  printf ("s1 = %#x, s2 = %#x\n", s1, s2);
+  if (s1 != s2)
+    abort ();
+
+  printf ("as3 = %#lx, as4 = %#lx\n",
+	  (unsigned long) as3, (unsigned long) as4);
+
+  p3 = as3->p;
+  p4 = as4->p;
+  printf ("p3 = %#x, p4 = %#x\n", p3, p4);
+  if (p3 != p4)
+    abort ();
+
+  q3 = as3->q;
+  q4 = as4->q;
+  printf ("q3 = %#x, q4 = %#x\n", q3, q4);
+  if (q3 != q4)
+    abort ();
+
+  r3 = as3->r;
+  r4 = as4->r;
+  printf ("r3 = %#x, r4 = %#x\n", r3, r4);
+  if (r3 != r4)
+    abort ();
+
+  s3 = as3->s;
+  s4 = as4->s;
+  printf ("s3 = %#x, s4 = %#x\n", s3, s4);
+  if (s3 != s4)
+    abort ();
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-17.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-17.c
@@ -1,0 +1,21 @@
+/* { dg-do compile } */
+/* { dg-options "-Os --save-temps" } */
+
+/* Test for a far pointer processing bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/8 .
+
+   GCC's induction variable optimization pass (`-fivopts') sometimes creates
+   nonsense "far" addresses --- with no segment override --- and passes them
+   to TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS, in order to estimate the costs
+   of using various types of addresses.  So we need to make sure that
+   TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS can gracefully handle such things.
+
+   (Note that (as of Nov 2017) this particular routine actually compiles to
+   better code if `-fivopts' is simply turned off.)  */
+
+unsigned my_strlen(char __far * fname)
+{
+  unsigned length = 0;
+  while (fname[length]) length++;
+  return length;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-17.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-17.c
@@ -8,10 +8,7 @@
    nonsense "far" addresses --- with no segment override --- and passes them
    to TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS, in order to estimate the costs
    of using various types of addresses.  So we need to make sure that
-   TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS can gracefully handle such things.
-
-   (Note that (as of Nov 2017) this particular routine actually compiles to
-   better code if `-fivopts' is simply turned off.)  */
+   TARGET_ADDR_SPACE_LEGITIMIZE_ADDRESS can gracefully handle such things.  */
 
 unsigned my_strlen(char __far * fname)
 {

--- a/gcc/testsuite/gcc.target/ia16/far-addr-17.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-17.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-Os --save-temps" } */
 
 /* Test for a far pointer processing bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/far-addr-18.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-18.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-Os --save-temps" } */
 
 /* Test for a far pointer processing bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/far-addr-18.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-18.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-options "-Os --save-temps" } */
+
+/* Test for a far pointer processing bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/9 .
+
+   (And thus did the local register allocation (LRA) pass say to me, "d00d,
+   you're doing it wrong.")  -- tkchia 20171114  */
+
+struct int_struct
+{
+  int i;
+};
+
+void incp(struct int_struct __far *p)
+{
+  p->i++;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-19.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-19.c
@@ -1,0 +1,51 @@
+/* { dg-do run } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* Test if the compiler successfully constructs the composite type (N1570
+   6.2.7) of a function involving the far address space, given several
+   declarations of the same function.  */
+
+void abort (void);
+int printf (const char *, ...);
+
+int f (unsigned __far matrix[][8], volatile unsigned __far vector[128]);
+int f (unsigned __far matrix[16][8], volatile unsigned __far vector[]);
+
+int f (unsigned __far matrix[16][8], volatile unsigned __far vector[128])
+{
+  unsigned i, j, k;
+
+  if (sizeof (matrix[0]) != 8 * sizeof (unsigned))
+    abort ();
+
+  if (sizeof (&matrix[0][0]) != sizeof (void __far *))
+    abort ();
+
+  if (sizeof (&matrix[0]) != sizeof (void __far *))
+    abort ();
+
+  if (sizeof (vector[0]) != sizeof (unsigned))
+    abort ();
+
+  if (sizeof (&vector[0]) != sizeof (void __far *))
+    abort ();
+
+  for (i = 0, k = 0; i < 16; ++i)
+    {
+      for (j = 0; j < 8; ++j, ++k)
+	{
+	  printf ("%04x ", matrix[i][j]);
+	  if (matrix[i][j] != vector[k])
+	    abort ();
+	}
+      printf ("\n");
+    }
+}
+
+int main (void)
+{
+  f ((unsigned __far (*)[8]) 0xf000ff00ul,
+     (volatile unsigned __far *) 0xfff00000ul);
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-2.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-2.c
@@ -6,7 +6,7 @@
    to wrongly "optimize" this by placing the displacement in the final IA-16
    address expression. */
 
-int puts (const char *);
+int printf (const char *, ...);
 void abort (void);
 
 static inline unsigned long
@@ -16,6 +16,18 @@ read_displaced (unsigned long addr, unsigned disp)
 
   __asm ("" : "=k" (addr2) : "0" (addr));
   return *(volatile unsigned long __far *) (addr2 + disp);
+}
+
+static void
+test (const char *wx_name, unsigned long wx, unsigned long w0)
+{
+  if (wx == w0)
+    printf ("%s == w0\n", wx_name);
+  else
+    {
+      printf ("%s != w0 {%#lx != %#lx}\n", wx_name, wx, w0);
+      abort ();
+    }
 }
 
 int
@@ -29,42 +41,28 @@ main (void)
   /* Read longword at (__far *) (0x78000 + 0x8000), which should be the same
      as 0x80000, since we are doing the addition as integers first. */
   w1 = read_displaced (0x78000ul, 0x8000u);
-  if (w1 != w0)
-    abort ();
-  puts ("w1 == w0");
+  test ("w1", w1, w0);
 
   /* Read longword at (__far *) (0x78001 + 0x7fff), which should also be the
      same as 0x80000. */
   w2 = read_displaced (0x78001ul, 0x7fffu);
-  if (w2 != w0)
-    abort ();
-  puts ("w2 == w0");
+  test ("w2", w2, w0);
 
   /* And so on... */
   w3 = read_displaced (0x70001ul, 0xffffu);
-  if (w3 != w0)
-    abort ();
-  puts ("w3 == w0");
+  test ("w3", w3, w0);
 
   w4 = read_displaced (0x7ff80ul, 0x80u);
-  if (w4 != w0)
-    abort ();
-  puts ("w4 == w0");
+  test ("w4", w4, w0);
 
   w5 = read_displaced (0x7ff81ul, 0x7fu);
-  if (w5 != w0)
-    abort ();
-  puts ("w5 == w0");
+  test ("w5", w5, w0);
 
   w6 = read_displaced (0x7ff01ul, 0xffu);
-  if (w6 != w0)
-    abort ();
-  puts ("w6 == w0");
+  test ("w6", w6, w0);
 
   w7 = read_displaced (0x7fffful, 1u);
-  if (w7 != w0)
-    abort ();
-  puts ("w7 == w0");
+  test ("w7", w7, w0);
 
   return 0;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-2.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-2.c
@@ -1,0 +1,70 @@
+/* { dg-do run } */
+/* { dg-options "-O3 --save-temps" } */
+
+/* What happens when we add a displacement to a long integer _before_
+   converting it to a far pointer?  Make sure that the compiler does not try
+   to wrongly "optimize" this by placing the displacement in the final IA-16
+   address expression. */
+
+int puts (const char *);
+void abort (void);
+
+static inline unsigned long
+read_displaced (unsigned long addr, unsigned disp)
+{
+  unsigned long addr2;
+
+  __asm ("" : "=k" (addr2) : "0" (addr));
+  return *(volatile unsigned long __far *) (addr2 + disp);
+}
+
+int
+main (void)
+{
+  unsigned long w0, w1, w2, w3, w4, w5, w6, w7;
+
+  /* Read longword at 0x0008:0x0000. */
+  w0 = *(volatile unsigned long __far *) 0x80000;
+
+  /* Read longword at (__far *) (0x78000 + 0x8000), which should be the same
+     as 0x80000, since we are doing the addition as integers first. */
+  w1 = read_displaced (0x78000ul, 0x8000u);
+  if (w1 != w0)
+    abort ();
+  puts ("w1 == w0");
+
+  /* Read longword at (__far *) (0x78001 + 0x7fff), which should also be the
+     same as 0x80000. */
+  w2 = read_displaced (0x78001ul, 0x7fffu);
+  if (w2 != w0)
+    abort ();
+  puts ("w2 == w0");
+
+  /* And so on... */
+  w3 = read_displaced (0x70001ul, 0xffffu);
+  if (w3 != w0)
+    abort ();
+  puts ("w3 == w0");
+
+  w4 = read_displaced (0x7ff80ul, 0x80u);
+  if (w4 != w0)
+    abort ();
+  puts ("w4 == w0");
+
+  w5 = read_displaced (0x7ff81ul, 0x7fu);
+  if (w5 != w0)
+    abort ();
+  puts ("w5 == w0");
+
+  w6 = read_displaced (0x7ff01ul, 0xffu);
+  if (w6 != w0)
+    abort ();
+  puts ("w6 == w0");
+
+  w7 = read_displaced (0x7fffful, 1u);
+  if (w7 != w0)
+    abort ();
+  puts ("w7 == w0");
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-20.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-20.c
@@ -1,0 +1,20 @@
+/* { dg-do assemble } */
+/* { dg-options "-Os --save-temps" } */
+
+/* Test for a far pointer + induction variable optimization bug reported by
+   Bart Oldeman --- see https://github.com/tkchia/gcc-ia16/issues/10 .  */
+
+const char __far *get_end(const char __far * fname, unsigned length)
+{
+  while (length && *++fname)
+    length--;
+  return fname;
+}
+
+void pad_spaces(char __far *s)
+{
+  int i;
+  /* pad with spaces */
+  for (i = 10; s[i] == '\0'; i--)
+    s[i] = ' ';
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-21.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-21.c
@@ -1,0 +1,48 @@
+/* { dg-do run } */
+/* { dg-options "-Waddress -Os --save-temps" } */
+
+/* First test case for whether GCC warns properly for things like `char
+   __far *p, *q;' which are parsed differently by old DOS compilers.  Issue
+   found by Bart Oldeman --- https://github.com/tkchia/gcc-ia16/issues/11.  */
+
+void abort (void);
+
+int
+main (void)
+{
+  /* Far pointer declarations.  */
+  char __far *p1;	/* { dg-bogus	"will also go in .*__far.* space" } */
+  char __far *p2;	/* { dg-bogus	"will also go in .*__far.* space" } */
+
+  /* Generic pointer declarations.  */
+  char *p3, *p4;	/* { dg-bogus	"will also go in .*__far.* space" } */
+
+  /* Is p6 a far pointer?  GCC grammar says yes, Watcom says no.  */
+  long __far *p5, *p6;	/* { dg-warning	"will also go in .*__far.* space" } */
+
+  /* Watcom does not grok `__far char' at all, so this can have only one
+     meaning --- the GCC one.  */
+  __far char *p7, *p8;	/* { dg-bogus	"will also go in .*__far.* space" } */
+
+  /* No danger of misinterpretation here.  The `declaration-specifiers' here
+     are simply the word `char'.  So p9 is a far pointer to a generic
+     pointer, and p10 is a generic pointer to another generic pointer.  */
+  char * __far *p9, **p10; /* { dg-bogus "will also go in .*__far.* space" } */
+
+  if (sizeof (p6) != sizeof (long __far *))
+    abort ();
+
+  if (sizeof (p9) != sizeof (void __far *))
+    abort ();
+
+  if (sizeof (*p9) != sizeof (void *))
+    abort ();
+
+  if (sizeof (p10) != sizeof (void *))
+    abort ();
+
+  if (sizeof (*p10) != sizeof (void *))
+    abort ();
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-22.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-22.c
@@ -1,0 +1,28 @@
+/* { dg-do run } */
+/* { dg-options "-Waddress -Os --save-temps" } */
+
+/* Second test case for https://github.com/tkchia/gcc-ia16/issues/11.  */
+
+#include <stdarg.h>
+
+struct sigaction;
+void abort (void);
+
+int
+main (void)
+{
+  /* Are f2(.) and f3(.) far pointers?  */
+  extern unsigned __far
+    **f1 (int thang, const struct sigaction *sa, struct sigaction *osa, \
+	  void *(* restrict)[8][8], va_list ap, ...),
+    *f2 (char),		/* { dg-warning "will also go in .*__far.* space" } */
+    *f3 (float);
+
+  if (sizeof (f2 ('x')) != sizeof (unsigned __far *))
+    abort ();
+
+  if (sizeof (f3 (3.1415927)) != sizeof (unsigned __far *))
+    abort ();
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-23.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-23.c
@@ -1,0 +1,24 @@
+/* { dg-do run } */
+/* { dg-options "-Waddress -Os --save-temps" } */
+
+/* Third test case for https://github.com/tkchia/gcc-ia16/issues/11.  */
+
+void abort (void);
+
+int
+main (void)
+{
+  /* We test two things here --- whether the warning is triggered for
+     `typedef's, and whether the warning is triggered when we have two
+     `__far's in a row just before the declarators begin.  */
+  typedef char __far __far
+    *t1, *t2;		/* { dg-warning "will also go in .*__far.* space" } */
+
+  if (sizeof (t1) != sizeof (void __far *))
+    abort ();
+
+  if (sizeof (t2) != sizeof (void __far *))
+    abort ();
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-24.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-24.c
@@ -1,0 +1,47 @@
+/* { dg-do assemble } */
+/* { dg-options "-Os -fcall-used-es --save-temps" } */
+
+/* First test for a far pointer processing bug reported by Bart Oldeman ---
+   see https://github.com/tkchia/gcc-ia16/issues/14 .
+
+      "	tst14.c: In function ‘bar’:
+	tst14.c:11:1: internal compiler error: in reload_combine_note_use, at
+	postreload.c:1536
+	 }
+	 ^
+	0x84eac98 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1536
+	0x84eaa47 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1603
+	0x84eaa82 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1598
+	0x84eaa82 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1598
+	0x84eaa82 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1598
+	0x84eaa82 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1598
+	0x84eaa47 reload_combine_note_use
+		../../gcc-ia16/gcc/postreload.c:1603
+	0x84ec61a reload_combine
+		../../gcc-ia16/gcc/postreload.c:1386
+	0x84ed58f reload_cse_regs
+		../../gcc-ia16/gcc/postreload.c:68
+	0x84ed58f execute
+		../../gcc-ia16/gcc/postreload.c:2343
+	Please submit a full bug report,
+	with preprocessed source if appropriate.
+	Please include the complete backtrace with any bug report.
+	See <http://gcc.gnu.org/bugs.html> for instructions. "  */
+
+extern int foo(int, int);
+
+struct ab {
+  int a, b;
+};
+
+int bar(struct ab __far * x)
+{
+  x->a += foo(2, 16);
+  return 16 % x->b;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-25.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-25.c
@@ -1,0 +1,16 @@
+/* { dg-do assemble } */
+/* { dg-options "-Os -fcall-used-es --save-temps" } */
+
+/* Second test for a far pointer processing bug reported by Bart Oldeman ---
+   see https://github.com/tkchia/gcc-ia16/issues/14 .  */
+
+extern int foo(int, int);
+
+struct ab {
+  int a, b;
+};
+
+int bar(struct ab __far * x)
+{
+  return 16 % x->b;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-26.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-26.c
@@ -1,0 +1,12 @@
+/* { dg-do assemble } */
+/* { dg-options "-Os --save-temps" } */
+
+/* FAIL: Can we copy a moderately big structure from one far address to
+   another?  See https://github.com/tkchia/gcc-ia16/issues/12 .  */
+
+typedef struct { char f[64]; } T;
+
+void f (T __far *p, T __far *q)
+{
+  *p = *q;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-3.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-3.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-xfail-if "" *-*-* } */
+/* { dg-excess-errors "" } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
 /* FAIL: Can we create far address space variables and take their addresses? 

--- a/gcc/testsuite/gcc.target/ia16/far-addr-3.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-3.c
@@ -1,0 +1,22 @@
+/* { dg-do compile } */
+/* { dg-xfail-if "" *-*-* } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* FAIL: Can we create far address space variables and take their addresses? 
+   At the moment, this is not supported.  */
+
+int printf (const char *, ...);
+
+static int __far var = 1;
+
+int __far *
+p_var (void)
+{
+  return &var;
+}
+
+int main (void)
+{
+  printf ("%lx\n", (unsigned long) p_var ());
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-3.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-3.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-xfail-if "" *-*-* } */
 /* { dg-excess-errors "" } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */

--- a/gcc/testsuite/gcc.target/ia16/far-addr-4.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-4.c
@@ -1,0 +1,70 @@
+/* { dg-do run } */
+/* { dg-xfail-run-if "" *-*-* } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* FAIL: Arithmetic on a far pointer that causes the offset component to
+   wrap around.  This should really just leave the segment component alone,
+   like classical IA-16 compilers do.  Sometimes it does this --- e.g. if
+   `-fno-inline' is removed and read_displaced (...) is inlined --- but
+   sometimes it does not.  */
+
+int puts (const char *);
+void abort (void);
+
+static inline unsigned long
+read_displaced (unsigned long addr, unsigned disp)
+{
+  unsigned long addr2;
+
+  __asm ("" : "=k" (addr2) : "0" (addr));
+  return ((volatile unsigned long __far *) addr2) [disp];
+}
+
+int
+main (void)
+{
+  unsigned long w0, w1, w2, w3, w4, w5, w6, w7;
+
+  /* Read longword at 0x0008:0x0000. */
+  w0 = *(volatile unsigned long __far *) 0x80000;
+
+  /* Read longword at ((__far *) 0x88000 + 0x8000), which should be the same
+     as 0x80000. */
+  w1 = read_displaced (0x88000ul, 0x8000u / sizeof (unsigned long));
+  if (w1 != w0)
+    abort ();
+  puts ("w1 == w0");
+
+  /* And so on... */
+  w2 = read_displaced (0x88004ul, 0x7ffcu / sizeof (unsigned long));
+  if (w2 != w0)
+    abort ();
+  puts ("w2 == w0");
+
+  w3 = read_displaced (0x80004ul, 0xfffcu / sizeof (unsigned long));
+  if (w3 != w0)
+    abort ();
+  puts ("w3 == w0");
+
+  w4 = read_displaced (0x8ff80ul, 0x80u / sizeof (unsigned long));
+  if (w4 != w0)
+    abort ();
+  puts ("w4 == w0");
+
+  w5 = read_displaced (0x8ff84ul, 0x7cu / sizeof (unsigned long));
+  if (w5 != w0)
+    abort ();
+  puts ("w5 == w0");
+
+  w6 = read_displaced (0x8ff04ul, 0xfcu / sizeof (unsigned long));
+  if (w6 != w0)
+    abort ();
+  puts ("w6 == w0");
+
+  w7 = read_displaced (0x8fffcul, 4u / sizeof (unsigned long));
+  if (w7 != w0)
+    abort ();
+  puts ("w7 == w0");
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-4.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-4.c
@@ -17,10 +17,19 @@ read_displaced (unsigned long addr, unsigned disp)
   return ((volatile unsigned long __far *) addr2) [disp];
 }
 
+static inline unsigned long
+read_neg_displaced (unsigned long addr, unsigned disp)
+{
+  unsigned long addr2;
+
+  __asm ("" : "=k" (addr2) : "0" (addr));
+  return *((volatile unsigned long __far *) addr2 - disp);
+}
+
 int
 main (void)
 {
-  unsigned long w0, w1, w2, w3, w4, w5, w6, w7;
+  unsigned long w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13;
 
   /* Read longword at 0x0008:0x0000. */
   w0 = *(volatile unsigned long __far *) 0x80000;
@@ -62,6 +71,39 @@ main (void)
   if (w7 != w0)
     abort ();
   puts ("w7 == w0");
+
+  /* Read longword at ((__far *) 0 - 0xff80), which should be the same
+     as 0x80, and 0:0x80 == 0x8:0.  */
+  w8 = read_neg_displaced (0ul, 0xff80u / sizeof (unsigned long));
+  if (w8 != w0)
+    abort ();
+  puts ("w8 == w0");
+
+  /* And so on... */
+  w9 = read_neg_displaced (4ul, 0xff84u / sizeof (unsigned long));
+  if (w9 != w0)
+    abort ();
+  puts ("w9 == w0");
+
+  w10 = read_neg_displaced (8ul, 0xff88u / sizeof (unsigned long));
+  if (w10 != w0)
+    abort ();
+  puts ("w10 == w0");
+
+  w11 = read_neg_displaced (0x10ul, 0xff90u / sizeof (unsigned long));
+  if (w11 != w0)
+    abort ();
+  puts ("w11 == w0");
+
+  w12 = read_neg_displaced (0x20ul, 0xffa0u / sizeof (unsigned long));
+  if (w12 != w0)
+    abort ();
+  puts ("w12 == w0");
+
+  w13 = read_neg_displaced (0x40ul, 0xffc0u / sizeof (unsigned long));
+  if (w13 != w0)
+    abort ();
+  puts ("w13 == w0");
 
   return 0;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-4.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-4.c
@@ -1,12 +1,9 @@
 /* { dg-do run } */
-/* { dg-xfail-run-if "" *-*-* } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* FAIL: Arithmetic on a far pointer that causes the offset component to
-   wrap around.  This should really just leave the segment component alone,
-   like classical IA-16 compilers do.  Sometimes it does this --- e.g. if
-   `-fno-inline' is removed and read_displaced (...) is inlined --- but
-   sometimes it does not.  */
+/* Arithmetic on a far pointer that causes the offset component to wrap
+   around.  This should really just leave the segment component alone, like
+   classical IA-16 compilers do.  */
 
 int puts (const char *);
 void abort (void);

--- a/gcc/testsuite/gcc.target/ia16/far-addr-5.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-5.c
@@ -1,0 +1,46 @@
+/* { dg-do run } */
+/* { dg-options "-O3 --save-temps" } */
+
+/* Do something non-trivial with far pointers.
+
+   Assume that we are running with a PC-compatible ROM BIOS.  If we obtain
+   the clock tick count at 0x0040:0x006c and compare it to the clock tick
+   count obtained by the BIOS software interrupt $0x1a, they should be the
+   same (after a few tries, at least).
+
+   Reference:  www.ctyme.com/intr/rb-2271.htm  */
+
+static unsigned long
+irq0_clock_ticks1 (void)
+{
+  unsigned ticks_hi, ticks_lo, midnight;
+  unsigned long ticks;
+  __asm ("int $0x1a"
+    : "=c" (ticks_hi), "=d" (ticks_lo), "=a" (midnight)
+    : "2" (0x0000u)
+    : "bx", "cc", "memory");
+  ticks = (unsigned long) ticks_hi << 16 | ticks_lo;
+  return ticks;
+}
+
+static unsigned long
+irq0_clock_ticks2 (void)
+{
+  volatile unsigned long __far *p =
+    (volatile unsigned long __far *) 0x0040006c;
+  return *p;
+}
+
+int
+main (void)
+{
+  unsigned i;
+  for (i = 0; i < 100; ++i)
+    {
+      unsigned long ticks1 = irq0_clock_ticks1 ();
+      unsigned long ticks2 = irq0_clock_ticks2 ();
+      if (ticks1 == ticks2)
+	return 0;
+    }
+  return 1;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-6.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-6.c
@@ -1,0 +1,28 @@
+/* { dg-do run } */
+/* { dg-xfail-run-if "" *-*-* } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* FAIL: Can we cast a generic pointer to a far pointer?  Currently the
+   compiler sort of allows it (with a warning), but the resulting pointer is
+   bogus.  */
+
+#define VALUE	0x1337b33fu
+
+int printf (const char *, ...);
+void abort (void);
+
+static volatile unsigned long var = VALUE;
+
+volatile unsigned long __far *
+p_var (void)
+{
+  return (volatile unsigned long __far *) &var;
+}
+
+int main (void)
+{
+  volatile unsigned long __far *p = p_var ();
+  if (*p != VALUE)
+    abort ();
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-6.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-6.c
@@ -1,14 +1,11 @@
 /* { dg-do run } */
-/* { dg-excess-errors "" } */
-/* { dg-xfail-run-if "" *-*-* } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* FAIL: Can we cast a generic pointer to a far pointer?  Currently the
-   compiler sort of allows it (with a warning), but the resulting pointer is
-   bogus.  */
+/* Can we cast a generic pointer to a far pointer --- and back?  */
 
 #define VALUE1	0x1337b33fu
-#define VALUE2	0xb33ffe3du
+#define VALUE2	0xb3effe3du
+#define VALUE3	0xcafe13e7u
 
 int printf (const char *, ...);
 void abort (void);
@@ -24,12 +21,18 @@ p_var (void)
 int main (void)
 {
   volatile unsigned long __far *p = p_var ();
+  volatile unsigned long *q;
 
   if (*p != VALUE1)
     abort ();
 
   var = VALUE2;
   if (*p != VALUE2)
+    abort ();
+
+  q = (volatile unsigned long *)p;
+  *p = VALUE3;
+  if (*q != VALUE3)
     abort ();
 
   return 0;

--- a/gcc/testsuite/gcc.target/ia16/far-addr-6.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-6.c
@@ -1,4 +1,5 @@
 /* { dg-do run } */
+/* { dg-excess-errors "" } */
 /* { dg-xfail-run-if "" *-*-* } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
@@ -6,12 +7,13 @@
    compiler sort of allows it (with a warning), but the resulting pointer is
    bogus.  */
 
-#define VALUE	0x1337b33fu
+#define VALUE1	0x1337b33fu
+#define VALUE2	0xb33ffe3du
 
 int printf (const char *, ...);
 void abort (void);
 
-static volatile unsigned long var = VALUE;
+static volatile unsigned long var = VALUE1;
 
 volatile unsigned long __far *
 p_var (void)
@@ -22,7 +24,13 @@ p_var (void)
 int main (void)
 {
   volatile unsigned long __far *p = p_var ();
-  if (*p != VALUE)
+
+  if (*p != VALUE1)
     abort ();
+
+  var = VALUE2;
+  if (*p != VALUE2)
+    abort ();
+
   return 0;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-7.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-7.c
@@ -1,0 +1,23 @@
+/* { dg-do run } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* Using a far pointer to loop through an area of conventional memory.  */
+
+int printf (const char *, ...);
+
+unsigned
+hash (void)
+{
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xb8000000ul;
+  unsigned i, h = 0;
+  for (i = 0; i < 2000; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
+int
+main (void)
+{
+  printf ("%#x\n", hash ());
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-7.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-7.c
@@ -1,15 +1,16 @@
 /* { dg-do run } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* Using a far pointer to loop through an area of conventional memory.  */
+/* Using a far pointer to loop through an area of (emulated) BIOS ROM.  */
 
 int printf (const char *, ...);
 
-unsigned
+unsigned long
 hash (void)
 {
-  volatile unsigned __far *p = (volatile unsigned __far *) 0xb8000000ul;
-  unsigned i, h = 0;
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xf0000000ul;
+  unsigned i;
+  unsigned long h = 0;
   for (i = 0; i < 2000; ++i)
     h = 5 * h ^ *p++;
   return h;
@@ -18,6 +19,6 @@ hash (void)
 int
 main (void)
 {
-  printf ("%#x\n", hash ());
+  printf ("%#lx\n", hash ());
   return 0;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-7.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-7.c
@@ -1,17 +1,32 @@
 /* { dg-do run } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* Using a far pointer to loop through an area of (emulated) BIOS ROM.  */
+/* Using a far pointer to `volatile' loop through an area of (emulated) BIOS
+   ROM.  The optimized routine should give the exact same results as the
+   unoptimized routine.  */
 
 int printf (const char *, ...);
 
+__attribute__ ((optimize ("O3")))
 unsigned long
-hash (void)
+hash1 (void)
 {
-  volatile unsigned __far *p = (volatile unsigned __far *) 0xf0000000ul;
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xfff00000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 2000; ++i)
+  for (i = 0; i < 0x80u; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
+__attribute__ ((optimize ("O0")))
+unsigned long
+hash2 (void)
+{
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xfff00000ul;
+  unsigned i;
+  unsigned long h = 0;
+  for (i = 0; i < 0x80u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -19,6 +34,7 @@ hash (void)
 int
 main (void)
 {
-  printf ("%#lx\n", hash ());
-  return 0;
+  unsigned long h1 = hash1 (), h2 = hash2 ();
+  printf ("%#lx %#lx\n", h1, h2);
+  return h1 == h2 ? 0 : 1;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-7.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-7.c
@@ -3,7 +3,8 @@
 
 /* Using a far pointer to `volatile' loop through an area of (emulated) BIOS
    ROM.  The optimized routine should give the exact same results as the
-   unoptimized routine.  */
+   unoptimized routine.  Furthermore, reading from 0xfff0:0x0000 should give
+   the same results as reading from 0xf000:0xff00.  */
 
 int printf (const char *, ...);
 
@@ -31,10 +32,21 @@ hash2 (void)
   return h;
 }
 
+unsigned long
+hash3 (void)
+{
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xf000ff00ul;
+  unsigned i;
+  unsigned long h = 0;
+  for (i = 0; i < 0x80u; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
 int
 main (void)
 {
-  unsigned long h1 = hash1 (), h2 = hash2 ();
-  printf ("%#lx %#lx\n", h1, h2);
-  return h1 == h2 ? 0 : 1;
+  unsigned long h1 = hash1 (), h2 = hash2 (), h3 = hash3 ();
+  printf ("%#lx %#lx %#lx\n", h1, h2, h3);
+  return h1 == h2 && h1 == h3 ? 0 : 1;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-8.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-8.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+/* { dg-xfail-if "" *-*-* }
+
+/* FAIL: Far pointers to non-volatile things.  They cause the compiler to
+   crash (and they should not).  */
+
+unsigned
+hash (void)
+{
+  unsigned __far *p = (unsigned __far *) 0xb8000000ul;
+  unsigned i, h = 0;
+  for (i = 0; i < 2000; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-8.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-8.c
@@ -1,13 +1,12 @@
 /* { dg-do run } */
-/* { dg-xfail-if "" *-*-* } */
-/* { dg-xfail-run-if "" *-*-* } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
 
-/* FAIL: Far pointers to non-volatile things.  For the same read-only memory
-   area, using non-volatile pointers should give the same results as using
-   volatile pointers.
+/* Far pointers to non-volatile things.  For the same read-only memory area,
+   using pointers to non-`volatile' should give the same results as using
+   pointers to `volatile'.
 
-   Currently this crashes the compiler.  */
+   We also include further tests where the _pointers_ themselves are made
+   volatile (not necessarily the things pointed to).  */
 
 int printf (const char *, ...);
 
@@ -17,7 +16,7 @@ hash1 (void)
   unsigned __far *p = (unsigned __far *) 0xf0000000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 2000; ++i)
+  for (i = 0; i < 0x8000u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -28,7 +27,30 @@ hash2 (void)
   volatile unsigned __far *p = (volatile unsigned __far *) 0xf0000000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 2000; ++i)
+  for (i = 0; i < 0x8000u; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
+unsigned long
+hash3 (void)
+{
+  unsigned __far * volatile p = (unsigned __far *) 0xf0000000ul;
+  unsigned i;
+  unsigned long h = 0;
+  for (i = 0; i < 0x8000u; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
+unsigned long
+hash4 (void)
+{
+  volatile unsigned __far * volatile p =
+    (volatile unsigned __far *) 0xf0000000ul;
+  unsigned i;
+  unsigned long h = 0;
+  for (i = 0; i < 0x8000u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -36,7 +58,7 @@ hash2 (void)
 int
 main (void)
 {
-  unsigned long h1 = hash1 (), h2 = hash2 ();
-  printf ("%#lx %#lx\n", h1, h2);
-  return h1 == h2 ? 0 : 1;
+  unsigned long h1 = hash1 (), h2 = hash2 (), h3 = hash3 (), h4 = hash4 ();
+  printf ("%#lx %#lx %#lx %#lx\n", h1, h2, h3, h4);
+  return h1 == h2 && h1 == h3 && h1 == h4 ? 0 : 1;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-8.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-8.c
@@ -13,10 +13,10 @@ int printf (const char *, ...);
 unsigned long
 hash1 (void)
 {
-  unsigned __far *p = (unsigned __far *) 0xf0000000ul;
+  unsigned __far *p = (unsigned __far *) 0xfff00000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 0x8000u; ++i)
+  for (i = 0; i < 0x80u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -24,10 +24,10 @@ hash1 (void)
 unsigned long
 hash2 (void)
 {
-  volatile unsigned __far *p = (volatile unsigned __far *) 0xf0000000ul;
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xfff00000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 0x8000u; ++i)
+  for (i = 0; i < 0x80u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -35,10 +35,10 @@ hash2 (void)
 unsigned long
 hash3 (void)
 {
-  unsigned __far * volatile p = (unsigned __far *) 0xf0000000ul;
+  unsigned __far * volatile p = (unsigned __far *) 0xfff00000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 0x8000u; ++i)
+  for (i = 0; i < 0x80u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }
@@ -47,10 +47,10 @@ unsigned long
 hash4 (void)
 {
   volatile unsigned __far * volatile p =
-    (volatile unsigned __far *) 0xf0000000ul;
+    (volatile unsigned __far *) 0xfff00000ul;
   unsigned i;
   unsigned long h = 0;
-  for (i = 0; i < 0x8000u; ++i)
+  for (i = 0; i < 0x80u; ++i)
     h = 5 * h ^ *p++;
   return h;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-8.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-8.c
@@ -1,16 +1,42 @@
-/* { dg-do compile } */
+/* { dg-do run } */
+/* { dg-xfail-if "" *-*-* } */
+/* { dg-xfail-run-if "" *-*-* } */
 /* { dg-options "-O3 -fno-inline --save-temps" } */
-/* { dg-xfail-if "" *-*-* }
 
-/* FAIL: Far pointers to non-volatile things.  They cause the compiler to
-   crash (and they should not).  */
+/* FAIL: Far pointers to non-volatile things.  For the same read-only memory
+   area, using non-volatile pointers should give the same results as using
+   volatile pointers.
 
-unsigned
-hash (void)
+   Currently this crashes the compiler.  */
+
+int printf (const char *, ...);
+
+unsigned long
+hash1 (void)
 {
-  unsigned __far *p = (unsigned __far *) 0xb8000000ul;
-  unsigned i, h = 0;
+  unsigned __far *p = (unsigned __far *) 0xf0000000ul;
+  unsigned i;
+  unsigned long h = 0;
   for (i = 0; i < 2000; ++i)
     h = 5 * h ^ *p++;
   return h;
+}
+
+unsigned long
+hash2 (void)
+{
+  volatile unsigned __far *p = (volatile unsigned __far *) 0xf0000000ul;
+  unsigned i;
+  unsigned long h = 0;
+  for (i = 0; i < 2000; ++i)
+    h = 5 * h ^ *p++;
+  return h;
+}
+
+int
+main (void)
+{
+  unsigned long h1 = hash1 (), h2 = hash2 ();
+  printf ("%#lx %#lx\n", h1, h2);
+  return h1 == h2 ? 0 : 1;
 }

--- a/gcc/testsuite/gcc.target/ia16/far-addr-9.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-9.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-O0" } */
+
+/* Test for a pointer arithmetic bug reported by Bart Oldeman --- see
+   https://github.com/tkchia/gcc-ia16/issues/4 .  */
+
+char __far *inc(char __far *p)
+{
+  return &p[1];
+}

--- a/gcc/testsuite/gcc.target/ia16/far-addr-9.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-9.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O0" } */
+/* { dg-options "-O0 --save-temps" } */
 
 /* Test for a pointer arithmetic bug reported by Bart Oldeman --- see
    https://github.com/tkchia/gcc-ia16/issues/4 .  */

--- a/gcc/testsuite/gcc.target/ia16/far-addr-9.c
+++ b/gcc/testsuite/gcc.target/ia16/far-addr-9.c
@@ -1,4 +1,4 @@
-/* { dg-do compile } */
+/* { dg-do assemble } */
 /* { dg-options "-O0 --save-temps" } */
 
 /* Test for a pointer arithmetic bug reported by Bart Oldeman --- see

--- a/gcc/testsuite/gcc.target/ia16/ia16.exp
+++ b/gcc/testsuite/gcc.target/ia16/ia16.exp
@@ -1,0 +1,27 @@
+# Modified from gcc/testsuite/gcc.target/aarch64/aarch64.exp by TK Chia.
+
+# GCC testsuite that uses the `dg.exp' driver.
+
+# Exit immediately if this isn't an IA-16 target.
+if {![istarget ia16-*-elf] } then {
+  return
+}
+
+# Load support procs.
+load_lib gcc-dg.exp
+
+# If a testcase doesn't have special options, use these.
+global DEFAULT_CFLAGS
+if ![info exists DEFAULT_CFLAGS] then {
+    set DEFAULT_CFLAGS " -ansi -pedantic-errors"
+}
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.\[cCS\]]] \
+	"" $DEFAULT_CFLAGS
+
+# All done.
+dg-finish

--- a/gcc/testsuite/gcc.target/ia16/seg-reg-1.c
+++ b/gcc/testsuite/gcc.target/ia16/seg-reg-1.c
@@ -1,0 +1,27 @@
+/* { dg-do run } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* Test that the "Q" register constraint works properly.  */
+
+void abort (void);
+
+unsigned
+f (void)
+{
+  unsigned x;
+  __asm(".ifnc \"%%ds\", \"%0\"; "
+	".ifnc \"%%es\", \"%0\"; "
+	".err; "
+	".endif; "
+	".endif"
+    : "=Q" (x) : "0" (0x1337));
+  return x;
+}
+
+int
+main (void)
+{
+  if (f () != 0x1337)
+    abort ();
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/ia16/seg-reg-2.c
+++ b/gcc/testsuite/gcc.target/ia16/seg-reg-2.c
@@ -1,0 +1,25 @@
+/* { dg-do run } */
+/* { dg-options "-O3 -fno-inline --save-temps" } */
+
+/* Test that the "e" register constraint works properly.  */
+
+void abort (void);
+
+int
+f (void)
+{
+  int x;
+  __asm(".ifnc \"%%es\", \"%0\"; "
+	".err; "
+	".endif"
+    : "=e" (x) : "0" (0xbe3f));
+  return x;
+}
+
+int
+main (void)
+{
+  if (f () != 0xbe3f)
+    abort ();
+  return 0;
+}

--- a/gcc/tree-ssa-address.c
+++ b/gcc/tree-ssa-address.c
@@ -248,8 +248,7 @@ addr_for_mem_ref (struct mem_address *addr, addr_space_t as,
 	*templ->off_p = off;
 
       address = templ->ref;
-      if (pointer_mode != address_mode
-	  || ! memory_address_addr_space_p (address_mode, address, as))
+      if (pointer_mode != address_mode)
 	{
 	  address = convert_memory_address_addr_space (address_mode,
 						       address, as);
@@ -270,8 +269,7 @@ addr_for_mem_ref (struct mem_address *addr, addr_space_t as,
 	 : NULL_RTX);
 
   gen_addr_rtx (pointer_mode, sym, bse, idx, st, off, &address, NULL, NULL);
-  if (pointer_mode != address_mode
-      || ! memory_address_addr_space_p (address_mode, address, as))
+  if (pointer_mode != address_mode)
     address = convert_memory_address_addr_space (address_mode, address, as);
   return address;
 }

--- a/gcc/tree-ssa-address.c
+++ b/gcc/tree-ssa-address.c
@@ -247,7 +247,15 @@ addr_for_mem_ref (struct mem_address *addr, addr_space_t as,
       if (off)
 	*templ->off_p = off;
 
-      return templ->ref;
+      address = templ->ref;
+      if (pointer_mode != address_mode
+	  || ! memory_address_addr_space_p (address_mode, address, as))
+	{
+	  address = convert_memory_address_addr_space (address_mode,
+						       address, as);
+	  templ->ref = address;
+	}
+      return address;
     }
 
   /* Otherwise really expand the expressions.  */
@@ -262,8 +270,9 @@ addr_for_mem_ref (struct mem_address *addr, addr_space_t as,
 	 : NULL_RTX);
 
   gen_addr_rtx (pointer_mode, sym, bse, idx, st, off, &address, NULL, NULL);
-  if (pointer_mode != address_mode)
-    address = convert_memory_address (address_mode, address);
+  if (pointer_mode != address_mode
+      || ! memory_address_addr_space_p (address_mode, address, as))
+    address = convert_memory_address_addr_space (address_mode, address, as);
   return address;
 }
 

--- a/gcc/tree-ssa-loop-ivopts.c
+++ b/gcc/tree-ssa-loop-ivopts.c
@@ -1173,7 +1173,26 @@ find_bivs (struct ivopts_data *data)
       if (step)
 	{
 	  if (POINTER_TYPE_P (type))
-	    step = convert_to_ptrofftype (step);
+	    {
+#ifdef MODE_SEGMENT_REG_CLASS
+	      /* Special case hack for ia16-elf.  Apparently IA-16 far
+		 pointers (32-bit) do not yet interact well with this
+		 optimization, partly because they are bigger than the
+		 16-bit `sizetype'.
+
+		 Changing `sizetype' to 32-bit caused other problems --- GCC
+		 crashed while trying to compile libgcc.
+
+		 (Plus, _if_ far pointers are implemented properly, they
+		 will also have arithmetic rules that differ from normal
+		 `unsigned long' arithmetic.  And this will likely lead to
+		 even more weirdness down the road, unless we find a way to
+		 teach this compiler pass about those rules...)  */
+	      if (TYPE_ADDR_SPACE (TREE_TYPE (type)) != ADDR_SPACE_GENERIC)
+		continue;
+#endif
+	      step = convert_to_ptrofftype (step);
+	    }
 	  else
 	    step = fold_convert (type, step);
 	}

--- a/gcc/tree-ssa-loop-ivopts.c
+++ b/gcc/tree-ssa-loop-ivopts.c
@@ -1174,7 +1174,7 @@ find_bivs (struct ivopts_data *data)
 	{
 	  if (POINTER_TYPE_P (type))
 	    {
-#ifdef MODE_SEGMENT_REG_CLASS
+#ifdef TARGET_ADDR_SPACE_WEIRD_P
 	      /* Special case hack for ia16-elf.  Apparently IA-16 far
 		 pointers (32-bit) do not yet interact well with this
 		 optimization, partly because they are bigger than the
@@ -1188,7 +1188,8 @@ find_bivs (struct ivopts_data *data)
 		 `unsigned long' arithmetic.  And this will likely lead to
 		 even more weirdness down the road, unless we find a way to
 		 teach this compiler pass about those rules...)  */
-	      if (TYPE_ADDR_SPACE (TREE_TYPE (type)) != ADDR_SPACE_GENERIC)
+	      if (TARGET_ADDR_SPACE_WEIRD_P
+		  (TYPE_ADDR_SPACE (TREE_TYPE (type))))
 		continue;
 #endif
 	      step = convert_to_ptrofftype (step);

--- a/gcc/tree-ssa-loop-ivopts.c
+++ b/gcc/tree-ssa-loop-ivopts.c
@@ -2852,6 +2852,13 @@ add_candidate_1 (struct ivopts_data *data,
   if (pos != IP_ORIGINAL)
     {
       orig_type = TREE_TYPE (base);
+#ifdef TARGET_ADDR_SPACE_WEIRD_P
+      /* Special case hack for ia16-elf.  */
+      if (POINTER_TYPE_P (orig_type)
+	  && TARGET_ADDR_SPACE_WEIRD_P (TYPE_ADDR_SPACE
+					(TREE_TYPE (orig_type))))
+	return NULL;
+#endif
       type = generic_type_for (orig_type);
       if (type != orig_type)
 	{


### PR DESCRIPTION
My proposed patches for `gcc-ia16` to add some (very preliminary) support for segment:offset far pointers.  With the patches, I can now write something like this:

```c
int main(void)
{
	static const char msg[] = " -*- Hello world! -*- ", *p;
	volatile unsigned __far *q = (unsigned __far *)0xb8000000ul;
	for (p = msg; *p; ++p)
		*q++ = 0x0f00u | (unsigned char)*p;
	return 0;
}
```

As I am still not very familiar with `gcc` internals, I suspect the patches will need a lot more improvement and testing to pass muster, but I am submitting them in case they might be useful.